### PR TITLE
Added easy command for highlighting C++ code

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -39,7 +39,24 @@
 % packages %
 %%%%%%%%%%%%
 
+\usepackage{scontents}
+\makeatletter
+\let\verbatimsc\@undefined
+\let\endverbatimsc\@undefined
+\makeatother
 \usepackage{minted}
+\newminted{tex}{linenos}
+\newenvironment{verbatimsc}
+               {\VerbatimEnvironment
+                 \begin{minted}[linenos,escapeinside=||]{cpp}}
+               {\end{minted}}
+\newcommand\highlightCppCode[2]{
+  \renewenvironment{verbatimsc}
+                   {\VerbatimEnvironment
+                     \begin{minted}[linenos,highlightlines={#1},escapeinside=||]{cpp}}
+                   {\end{minted}}
+  \typestored{#2}
+}
 \newminted{cpp}{gobble=4,linenos}
 \newminted{shell-session}{gobble=4}
 \newminted[makefile]{shell-session}{gobble=4}


### PR DESCRIPTION
Based on an idea from @hageboeck, and complemented by the usage of the scontents package, one can now simply reuse C++ code and highlight it.
Here is an example code :

```latex
% define a piece of C++ code, named "code"
% this is kind of a verbatim environment and braces are properly matched
\Scontents*[store-cmd=code]{
int a = 0;
{
  int b[4];
  b[0] = a;
}
// Doesn't compile:
// b[1] = a + 1;
}
% reusing n times the same code on different slides and highlighting the given line number
% arguments to highlightCppCode are the line number(s) (syntax from the highlightlines argument of minted)
% and the name of the code snippet to use, which must have been defined via scontents beforehand
\begin{overprint}[\columnwidth]
  \onslide<1>
  \highlightCppCode{1}{code}
  \onslide<2>
  \highlightCppCode{3}{code}
  \onslide<3>
  \highlightCppCode{4}{code}
  \onslide<4>
  \highlightCppCode{7}{code}
\end{overprint}
