### PR TITLE
Prefer new/delete to malloc/free in example code

### DIFF
--- a/talk/objectorientation.tex
+++ b/talk/objectorientation.tex
@@ -483,12 +483,12 @@
     private:
       int len;
       int* data;
-    }
+    };
     Vector::Vector(int n) : len(n) {
-      data = (int*)malloc(n*sizeof(int));
+      data = new int[n];
     }
     Vector::~Vector() {
-      free(data);
+      delete[] data;
     }
   \end{cppcode}
 \end{frame}
@@ -551,15 +551,15 @@
       Vector(const Vector &other);
       ~Vector();
       ...
-    }
+    };
     Vector::Vector(int n) : len(n) {
-      data = (int*)calloc(n, sizeof(int));
+      data = new int[n];
     }
     Vector::Vector(const Vector &other) : len(other.len) {
-      data = (int*)malloc(len*sizeof(int));
+      data = new int[len];
       memcpy(data, other.data, len);
     }
-    Vector::~Vector() { free(data); }
+    Vector::~Vector() { delete[] data; }
   \end{cppcode}
 \end{frame}
 


### PR DESCRIPTION
Following @sponce 's "you should not use malloc" this morning.

I realize that in one of the occurrences the `new` is not exactly equivalent to the `calloc`, but I think that zero-initialization of the memory is beyond the example's scope anyway.