### PR TITLE
Avoid creating shared library in code/hello

### DIFF
--- a/code/hello/Makefile
+++ b/code/hello/Makefile
@@ -1,11 +1,8 @@
-all: libhello.so hello
+all: hello
 solution: all
 
 clean:
 	rm -f *o *so hello *~ callgrind.out.*
 
-libhello.so: hello.cpp hello.hpp
-	$(CXX) --std=c++17 -g -Wall -Wextra -shared -fPIC -o $@ $<
-
-hello : main.cpp libhello.so
+hello : main.cpp hello.cpp
 	$(CXX) --std=c++17 -g -Wall -Wextra -o $@ $^

--- a/code/hello/README.md
+++ b/code/hello/README.md
@@ -8,7 +8,6 @@ This example should help to check that your machine is well installed.
 Try:
 ```
 make
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:.
 ./hello
 ```
 


### PR DESCRIPTION
Several students were confused by that extra file and/or forgot to
`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.` and/or asked what that
magic spell did.

Explanation of the compilation chain is on the last day, we could
leave creation of shared objects and LD_LIBRARY_PATH for that day.

If people agree with this change I can apply similar patches to all exercises of days 1, 2 and 3.