### PR TITLE
add a section on static assert, improve SFINAE with void_t

### DIFF
--- a/talk/expert.tex
+++ b/talk/expert.tex
@@ -383,7 +383,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Using SFINAE for instrospection}
+  \frametitleii{Using SFINAE for introspection}
   \begin{block}{The main idea}
     \begin{itemize}
     \item use a template specialization
@@ -403,9 +403,43 @@
       struct hasFoo<T, decltype(std::declval<T>().foo())>
         : std::true_type {};
 
-      std::cout << hasFoo<MyType>::value << std::endl;
+      struct A{}; struct B{void foo();}; struct C{int foo();};
+      static_assert(!hasFoo<A>::value, "A has no Foo()");
+      static_assert(hasFoo<B>::value, "B has Foo()");
+      // static_assert(hasFoo<C>::value, "C has Foo()"); fails assertion!
     \end{cppcode*}
   \end{exampleblock}  
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitleii{Using \texttt{void\_t} to simplify SFINAE expressions \hfill \cpp17}
+  \begin{block}{Concept}
+    \begin{cppcode*}{gobble=2}
+      template <typename... >
+      using void_t = void;
+    \end{cppcode*}
+
+    \begin{itemize}
+    \item Maps a sequence of given types to void
+    \item Introduced in \cpp17 though trivial to copy to \cpp11
+    \item Can thus be used in specialization to check the validity of an expression
+    \end{itemize}
+  \end{block}
+  \begin{exampleblock}{Example}
+    \begin{cppcode*}{}
+      template <typename T, typename = void>
+      struct hasFoo : std::false_type {};
+
+      template <typename T>
+      struct hasFoo<T, std::void_t<decltype(std::declval<T>().foo())>>
+      : std::true_type {};
+
+      struct A{}; struct B{void foo()}; struct C{int foo();};
+      static_assert(!hasFoo<A>::value, "A has no Foo()");
+      static_assert(hasFoo<B>::value, "B has Foo()");
+      static_assert(hasFoo<C>::value, "C has Foo()");
+    \end{cppcode*}
+  \end{exampleblock}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/expert.tex
+++ b/talk/expert.tex
@@ -398,48 +398,51 @@
     \begin{cppcode*}{}
       template <typename T, typename = void>
       struct hasFoo : std::false_type {};
-
       template <typename T>
       struct hasFoo<T, decltype(std::declval<T>().foo())>
         : std::true_type {};
-
-      struct A{}; struct B{void foo();}; struct C{int foo();};
+      struct A{}; struct B{void foo();};
       static_assert(!hasFoo<A>::value, "A has no Foo()");
       static_assert(hasFoo<B>::value, "B has Foo()");
-      // static_assert(hasFoo<C>::value, "C has Foo()"); fails assertion!
     \end{cppcode*}
   \end{exampleblock}  
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Using \texttt{void\_t} to simplify SFINAE expressions \hfill \cpp17}
+  \frametitleit{Using \texttt{void\_t} to simplify SFINAE expressions}
   \begin{block}{Concept}
     \begin{cppcode*}{gobble=2}
       template <typename... >
       using void_t = void;
     \end{cppcode*}
-
     \begin{itemize}
     \item Maps a sequence of given types to void
     \item Introduced in \cpp17 though trivial to copy to \cpp11
     \item Can thus be used in specialization to check the validity of an expression
     \end{itemize}
   \end{block}
-  \begin{exampleblock}{Example}
-    \begin{cppcode*}{}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitleit{Previous example using \texttt{void\_t}}
+    \begin{exampleblock}{Example}
+      \begin{cppcode*}{}
       template <typename T, typename = void>
       struct hasFoo : std::false_type {};
 
       template <typename T>
-      struct hasFoo<T, std::void_t<decltype(std::declval<T>().foo())>>
+      struct hasFoo<T,
+         std::void_t<decltype(std::declval<T>().foo())>>
       : std::true_type {};
 
-      struct A{}; struct B{void foo()}; struct C{int foo();};
-      static_assert(!hasFoo<A>::value, "A has no Foo()");
-      static_assert(hasFoo<B>::value, "B has Foo()");
-      static_assert(hasFoo<C>::value, "C has Foo()");
-    \end{cppcode*}
-  \end{exampleblock}
+      struct A{}; struct B{void foo()};
+      struct C{int foo();};
+
+      static_assert(!hasFoo<A>::value,"Unexpected Foo()");
+      static_assert(hasFoo<B>::value, "expected Foo()");
+      static_assert(hasFoo<C>::value, "expected Foo()");
+      \end{cppcode*}
+    \end{exampleblock}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/morelanguage.tex
+++ b/talk/morelanguage.tex
@@ -201,8 +201,7 @@
     constexpr DimLength km(1, 'k');
     constexpr float km_y = km.get('y');
     constexpr float km_i = km.get('i');
-    // static_assert(km_y == 1000, "Expected a km to be 1000 yards"); Fails compilation
-    static_assert(km_y == 1093, "Expected a km to be 1093 yards! ");
+    static_assert(km_y == 1093, "expected km == 1093 yards!");
   \end{cppcode*}
 \end{frame}
 

--- a/talk/morelanguage.tex
+++ b/talk/morelanguage.tex
@@ -119,6 +119,29 @@
 \end{frame}
 
 \begin{frame}[fragile]
+  \frametitleii{Static Assertions}
+  \begin{block}{static\_assert declaration}
+    \begin{itemize}
+    \item Performs compile time assertions; meaning a failed assertion stops compilation
+    \item The expression evaluated has to be a constexpr boolean expression
+    \item Purely evaluated at compile time, no effect at runtime
+    \item Often used in template programming to make assertion on types, can be
+      used to validate boolean compile time expressions
+    \end{itemize}
+  \end{block}
+  \pause
+  \begin{exampleblock}{Example}
+    \begin{cppcode*}{}
+      constexpr int f(int x) {
+        return x > 1 ? x * f(x - 1) : 1;
+      }
+      static_assert(f(5)==120,"Expected f(5) to be 120!");
+    \end{cppcode*}
+  \end{exampleblock}
+\end{frame}
+
+
+\begin{frame}[fragile]
   \frametitleii{Generalized Constant Expressions(2)}
   \begin{alertblock}{Few limitations}
     \begin{itemize}
@@ -154,7 +177,8 @@
     }
     constexpr float fromSI(const float v, const char unit) {
       switch (unit) {
-      case 'k': return 0.001*v;
+        case 'k': return 0.001*v;
+        case 'y': return 1.093*v;
       ...
       }
     }
@@ -177,8 +201,8 @@
     constexpr DimLength km(1, 'k');
     constexpr float km_y = km.get('y');
     constexpr float km_i = km.get('i');
-    std::cout << "1 km = " << km_y << " yards\n"
-              << "     = " << km_i << " inches\n";
+    // static_assert(km_y == 1000, "Expected a km to be 1000 yards"); Fails compilation
+    static_assert(km_y == 1093, "Expected a km to be 1093 yards! ");
   \end{cppcode*}
 \end{frame}
 

--- a/talk/morelanguage.tex
+++ b/talk/morelanguage.tex
@@ -123,7 +123,7 @@
   \begin{block}{static\_assert declaration}
     \begin{itemize}
     \item Performs compile time assertions; meaning a failed assertion stops compilation
-    \item The expression evaluated has to be a constexpr boolean expression
+    \item The expression has to be a constexpr boolean expression
     \item Purely evaluated at compile time, no effect at runtime
     \item Often used in template programming to make assertion on types, can be
       used to validate boolean compile time expressions


### PR DESCRIPTION
Use void_t for sfinae example so that we don't fixate on return types. Another option is just adding a `void()` in the end of decltype expr (eg: https://gcc.godbolt.org/z/9qGoe173x)

 Also introduce static_assert, I added this in the constexpr section though could make sense only in the expert section. 
Since the material is mostly template meta programming and probably not too relevant feel free to suggest/reject/modify this ;)