### PR TITLE
Simplify `\frametitle` commands

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -90,14 +90,6 @@
 \newcommand\frametitlecpp[2][98]{
   \frametitle{#2 \hfill \cpp#1}
 }
-% Deprecated:
-% used reverse leet speech for the numbers as a latex command cannot use numbers
-% 98 -> gb, 11 -> ii, 14 -> ia, 17 -> it, 20 -> so
-\newcommand\frametitlegb[1]{ \frametitlecpp[98]{#1} }
-\newcommand\frametitleii[1]{ \frametitlecpp[11]{#1} }
-\newcommand\frametitleia[1]{ \frametitlecpp[14]{#1} }
-\newcommand\frametitleit[1]{ \frametitlecpp[17]{#1} }
-\newcommand\frametitleso[1]{ \frametitlecpp[20]{#1} }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % easy class diagrams in tikz %

--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -86,23 +86,18 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % frametitle with C++ version %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Use as \frametitlecpp[14]{Title}
+\newcommand\frametitlecpp[2][98]{
+  \frametitle{#2 \hfill \cpp#1}
+}
+% Deprecated:
 % used reverse leet speech for the numbers as a latex command cannot use numbers
 % 98 -> gb, 11 -> ii, 14 -> ia, 17 -> it, 20 -> so
-\newcommand\frametitlegb[1]{
-  \frametitle{#1 \hfill \cpp98}
-}
-\newcommand\frametitleii[1]{
-  \frametitle{#1 \hfill \cpp11}
-}
-\newcommand\frametitleia[1]{
-  \frametitle{#1 \hfill \cpp14}
-}
-\newcommand\frametitleit[1]{
-  \frametitle{#1 \hfill \cpp17}
-}
-\newcommand\frametitleso[1]{
-  \frametitle{#1 \hfill \cpp20}
-}
+\newcommand\frametitlegb[1]{ \frametitlecpp[98]{#1} }
+\newcommand\frametitleii[1]{ \frametitlecpp[11]{#1} }
+\newcommand\frametitleia[1]{ \frametitlecpp[14]{#1} }
+\newcommand\frametitleit[1]{ \frametitlecpp[17]{#1} }
+\newcommand\frametitleso[1]{ \frametitlecpp[20]{#1} }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % easy class diagrams in tikz %

--- a/talk/basicconcepts.tex
+++ b/talk/basicconcepts.tex
@@ -3,7 +3,7 @@
 \subsection[Core]{Core syntax and types}
 
 \begin{frame}[fragile]
-  \frametitlegb{Hello World}
+  \frametitlecpp[98]{Hello World}
   \begin{cppcode}
     #include <iostream>
 
@@ -23,7 +23,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Comments}
+  \frametitlecpp[98]{Comments}
   \begin{cppcode}
     // simple comment for integer declaration
     int i;
@@ -45,7 +45,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Basic types(1)}
+  \frametitlecpp[98]{Basic types(1)}
   \begin{cppcode}
     bool b = true;            // boolean, true or false
 
@@ -62,7 +62,7 @@
   \end{cppcode}
 \end{frame}
 \begin{frame}[fragile]
-  \frametitlegb{Basic types(2)}
+  \frametitlecpp[98]{Basic types(2)}
   \begin{cppcode}
     int i = -123456;          // 32 bits signed integer
     unsigned int i = 1234567; // 32 bits signed integer
@@ -79,7 +79,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Portable numeric types}
+  \frametitlecpp[98]{Portable numeric types}
   \alert{One needs to include specific header}
   \begin{cppcode}
     #include <cstdint>
@@ -101,7 +101,7 @@
 \subsection[Ptr]{Arrays and Pointers}
 
 \begin{frame}[fragile]
-  \frametitlegb{Static arrays}
+  \frametitlecpp[98]{Static arrays}
   \begin{cppcode}
     int ai[4] = {1,2,3,4};
     int ai[] = {1,2,3,4};  // identical
@@ -134,7 +134,7 @@ int *pak = (int*)k;
 int l = *pak;
 }
 \begin{frame}[fragile]
-  \frametitlegb{Pointers}
+  \frametitlecpp[98]{Pointers}
   \begin{multicols}{2}
   \begin{overprint}[\columnwidth]
     \onslide<1> \highlightCppCode{}{code_arrays}
@@ -169,7 +169,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{nullptr}
+  \frametitlecpp[11]{nullptr}
   \begin{block}{Finally a \cpp~NULL pointer}
     \begin{itemize}
     \item if a pointer doesn't point to anything, set it to \mintinline{cpp}{nullptr}
@@ -189,7 +189,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Dynamic Arrays}
+  \frametitlecpp[98]{Dynamic Arrays}
   \begin{cppcode}
     #include <cstdlib>
     #include <cstring>
@@ -214,7 +214,7 @@ int l = *pak;
 \subsection[Compound]{Compound data types}
 
 \begin{frame}[fragile]
-  \frametitlegb{struct}
+  \frametitlecpp[98]{struct}
   \begin{mdframed}[style=simplebox]
     \center ``members'' grouped together under one name
   \end{mdframed}
@@ -260,7 +260,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{union}
+  \frametitlecpp[98]{union}
   \begin{mdframed}[style=simplebox]
     \center ``members'' packed together at same memory location
   \end{mdframed}
@@ -298,7 +298,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Enums}
+  \frametitlecpp[98]{Enums}
   \begin{multicols}{2}
     \begin{cppcode*}{gobble=2}
       enum VehicleType {
@@ -321,7 +321,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Scoped enumeration, aka enum class}
+  \frametitlecpp[11]{Scoped enumeration, aka enum class}
   \begin{block}{Same syntax as enum, with scope}
     \begin{cppcode*}{}
       enum class VehicleType { Bus, Car };
@@ -350,7 +350,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{More sensible example}
+  \frametitlecpp[98]{More sensible example}
   \begin{multicols}{2}
     \begin{cppcode*}{gobble=2}
       enum class ShapeType {
@@ -419,7 +419,7 @@ int l = *pak;
 \subsection[Refs]{References}
 
 \begin{frame}[fragile]
-  \frametitlegb{References}
+  \frametitlecpp[98]{References}
   \begin{block}{References}
     \begin{itemize}
       \item References allow for direct access to another object
@@ -444,7 +444,7 @@ int l = *pak;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Pointers vs References}
+  \frametitlecpp[98]{Pointers vs References}
   \begin{block}{Specificities of reference}
     \begin{itemize}
     \item natural syntax
@@ -472,7 +472,7 @@ int l = *pak;
 \subsection[$f()$]{Functions}
 
 \begin{frame}[fragile]
-  \frametitlegb{Functions}
+  \frametitlecpp[98]{Functions}
   \begin{multicols}{2}
     \begin{cppcode*}{gobble=2}
       // with return type
@@ -518,7 +518,7 @@ void printBSp(BigStruct &q) {
 printBSp(s); // no copy
 }
 \begin{frame}[fragile]
-  \frametitlegb{Functions: parameters are passed by value}
+  \frametitlecpp[98]{Functions: parameters are passed by value}
   \begin{multicols}{2}
     \begin{overprint}[\columnwidth]
       \onslide<1-2>
@@ -570,7 +570,7 @@ changeSS2(s);
 // s.a == 2
 }
 \begin{frame}[fragile]
-  \frametitlegb{Functions: pass by value or reference?}
+  \frametitlecpp[98]{Functions: pass by value or reference?}
   \begin{multicols}{2}
     \begin{overprint}[\columnwidth]
       \onslide<1>
@@ -620,7 +620,7 @@ changeSS2(s);
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Value vs. pointers and references}
+  \frametitlecpp[98]{Value vs. pointers and references}
   \begin{block}{Different ways to pass arguments to a function}
     \begin{itemize}
     \item by default arguments are passed by value (= copy, good for small types, e.g.\ numbers)
@@ -642,7 +642,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Functions}
+  \frametitlecpp[98]{Functions}
   \begin{alertblock}{Exercise}
     Familiarise yourself with pass by copy / pass by reference.
     \begin{itemize}
@@ -655,7 +655,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Functions: good practices}
+  \frametitlecpp[98]{Functions: good practices}
   \begin{onlyenv}<1>
     \begin{block}{Good practices with functions}
       \begin{itemize}
@@ -723,7 +723,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
 \subsection[Op]{Operators}
 
 \begin{frame}[fragile]
-  \frametitlegb{Operators(1)}
+  \frametitlecpp[98]{Operators(1)}
   \begin{block}{Binary \& Assignment Operators}
     \begin{cppcode*}{}
       int i = 1 + 4 - 2;  // 3
@@ -745,7 +745,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Operators(2)}
+  \frametitlecpp[98]{Operators(2)}
   \begin{block}{Bitwise and Assignment Operators}
     \begin{cppcode*}{}
       int i = 0xee & 0x55;  // 0x44
@@ -769,7 +769,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Operators(3)}
+  \frametitlecpp[98]{Operators(3)}
   \begin{block}{Comparison Operators}
     \begin{cppcode*}{}
       bool a = (3 == 3);  // true
@@ -791,7 +791,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
 \subsection[NS]{Scopes / namespaces}
 
 \begin{frame}[fragile]
-  \frametitlegb{Scope}
+  \frametitlecpp[98]{Scope}
   \begin{block}{Definition}
     Portion of the source code where a given name is valid \\
     Typically :
@@ -821,7 +821,7 @@ int a = 1;
 // b[1] = a + 1;
 }
 \begin{frame}[fragile]
-  \frametitlegb{Scope and lifetime of resources}
+  \frametitlecpp[98]{Scope and lifetime of resources}
   \begin{block}{Resource life time}
     \begin{itemize}
       \item Resources are allocated when declared
@@ -876,7 +876,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Namespaces}
+  \frametitlecpp[98]{Namespaces}
   \begin{itemize}
   \item Namespaces allow to segment your code to avoid name clashes
   \item They can be embedded to create hierarchies (separator is '::')
@@ -917,7 +917,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{Nested namespaces}
+  \frametitlecpp[17]{Nested namespaces}
   Easier way to declare nested namespaces
   \begin{alertblock}{\cpp14}
     \begin{cppcode*}{}
@@ -940,7 +940,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Anonymous namespaces}
+  \frametitlecpp[98]{Anonymous namespaces}
   \begin{exampleblock}{A namespace without a name !}
     \begin{cppcode*}{}
       namespace {
@@ -971,7 +971,7 @@ int a = 1;
 \subsection[Control]{Control instructions}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : if}
+  \frametitlecpp[98]{Control instructions : if}
   \begin{block}{if syntax}
     \begin{cppcode*}{}
       if (condition1) {
@@ -991,7 +991,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : if}
+  \frametitlecpp[98]{Control instructions : if}
   \begin{exampleblock}{Practical example}
     \begin{cppcode*}{}
       int collatz(int a) {
@@ -1011,7 +1011,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : conditional operator}
+  \frametitlecpp[98]{Control instructions : conditional operator}
   \begin{block}{Syntax}
     \begin{cppcode*}{linenos=false}
       test ? expression1 : expression2;
@@ -1038,7 +1038,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : switch}
+  \frametitlecpp[98]{Control instructions : switch}
   \begin{block}{Syntax}
     \begin{cppcode*}{gobble=2}
       switch(identifier) {
@@ -1063,7 +1063,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : switch}
+  \frametitlecpp[98]{Control instructions : switch}
   \begin{exampleblock}{Practical example}
     \begin{cppcode*}{}
       enum class Lang { FRENCH, GERMAN, ENGLISH, OTHER };
@@ -1088,7 +1088,7 @@ int a = 1;
 \AtBeginEnvironment{minted}{\renewcommand{\fcolorbox}[4][]{#4}}
 
 \begin{frame}[fragile]
-  \frametitleit{\texttt{[[fallthrough]]} attribute}
+  \frametitlecpp[17]{\texttt{[[fallthrough]]} attribute}
   \begin{alertblock}{\cpp14}
     \begin{cppcode}
       switch (c) {
@@ -1113,7 +1113,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{init-statements for if and switch}
+  \frametitlecpp[17]{init-statements for if and switch}
   Allows to simplify if and switch statements
   \begin{alertblock}{\cpp14}
     \begin{cppcode*}{}
@@ -1139,7 +1139,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : for loop}
+  \frametitlecpp[98]{Control instructions : for loop}
   \begin{block}{for loop syntax}
     \begin{cppcode*}{}
       for(initializations; condition; increments) {
@@ -1168,7 +1168,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Range based loops}
+  \frametitlecpp[11]{Range based loops}
   \begin{block}{Reason of being}
     \begin{itemize}
     \item simplifies loops tremendously
@@ -1192,7 +1192,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : while loop}
+  \frametitlecpp[98]{Control instructions : while loop}
   \begin{block}{while loop syntax}
     \begin{cppcode*}{}
       while(condition) {
@@ -1218,7 +1218,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Control instructions : commands}
+  \frametitlecpp[98]{Control instructions : commands}
   \begin{block}{control commands}
     \begin{description}
     \item[break] goes out of the loop
@@ -1245,7 +1245,7 @@ int a = 1;
 \subsection[.h]{Headers and interfaces}
 
 \begin{frame}[fragile]
-  \frametitlegb{Headers and interfaces}
+  \frametitlecpp[98]{Headers and interfaces}
   \begin{block}{Interface}
     Set of declarations defining some functionality
     \begin{itemize}
@@ -1269,7 +1269,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Preprocessor}
+  \frametitlecpp[98]{Preprocessor}
   \begin{cppcode}
     // file inclusion
     #include "hello.hpp"
@@ -1294,7 +1294,7 @@ int a = 1;
 \subsection[auto]{Auto keyword}
 
 \begin{frame}[fragile]
-  \frametitleii{Auto keyword}
+  \frametitlecpp[11]{Auto keyword}
   \begin{block}{Reason of being}
     \begin{itemize}
     \item many type declarations are redundant
@@ -1319,7 +1319,7 @@ int a = 1;
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Loops, references, auto}
+  \frametitlecpp[98]{Loops, references, auto}
   \begin{alertblock}{Exercise}
     Familiarise yourself with range-based for loops and references
     \begin{itemize}

--- a/talk/concurrency.tex
+++ b/talk/concurrency.tex
@@ -3,7 +3,7 @@
 \subsection[thr]{Threads and async}
 
 \begin{frame}[fragile]
-  \frametitleii{Basic concurrency}
+  \frametitlecpp[11]{Basic concurrency}
   \begin{block}{Threading}
     \begin{itemize}
     \item new object std::thread in \textless{}thread\textgreater{} header
@@ -27,7 +27,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{The thread constructor}
+  \frametitlecpp[11]{The thread constructor}
   \begin{exampleblock}{Can take a function and its arguments}
     \begin{cppcode*}{}
       void function(int j, double j) {...};
@@ -51,7 +51,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Basic asynchronicity}
+  \frametitlecpp[11]{Basic asynchronicity}
   \begin{block}{Concept}
     \begin{itemize}
     \item separation of the specification of what should be done and the retrieval of the results
@@ -76,7 +76,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Mixing the two}
+  \frametitlecpp[11]{Mixing the two}
   \begin{block}{Is async running concurrent code ?}
     \begin{itemize}
     \item it depends !
@@ -104,7 +104,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Fine grained control on asynchronous execution}
+  \frametitlecpp[11]{Fine grained control on asynchronous execution}
   \begin{block}{std::packaged\_task template}
     \begin{itemize}
     \item creates an asynchronous version of any function-like object
@@ -131,7 +131,7 @@
 \subsection[mutex]{Mutexes}
 
 \begin{frame}[fragile]
-  \frametitleii{Races}
+  \frametitlecpp[11]{Races}
   \begin{exampleblock}{Example code}
     \begin{cppcode*}{}
       int a = 0;
@@ -155,7 +155,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Atomicity}
+  \frametitlecpp[11]{Atomicity}
   \begin{exampleblock}{Definition (wikipedia)}
     \begin{itemize}
     \item an operation (or set of operations) is atomic if it appears to the rest of the system to occur instantaneously
@@ -180,7 +180,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Timing}
+  \frametitlecpp[11]{Timing}
   \begin{exampleblock}{Code}
     \begin{cppcode*}{}
       eax = a       // memory to register copy
@@ -213,7 +213,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Mutexes and Locks}
+  \frametitlecpp[11]{Mutexes and Locks}
   \begin{block}{Concept}
     \begin{itemize}
     \item Use locks to serialize access to a non-atomic piece of code
@@ -241,7 +241,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Mutexes and Locks}
+  \frametitlecpp[11]{Mutexes and Locks}
   \begin{block}{Good practice}
     \begin{itemize}
       \item Always use \texttt{scoped\_lock} (\cpp11: \texttt{lock\_guard})
@@ -263,7 +263,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Mutexes}
+  \frametitlecpp[11]{Mutexes}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item Go to code/race
@@ -276,7 +276,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Dead lock}
+  \frametitlecpp[11]{Dead lock}
   \begin{exampleblock}{Scenario}
     \begin{itemize}
     \item 2 mutexes, 2 threads
@@ -306,7 +306,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{How to avoid dead locks}
+  \frametitlecpp[11]{How to avoid dead locks}
   \begin{block}{Possible solutions}
     \begin{itemize}
     \item Never take several locks
@@ -323,7 +323,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Condition variables}
+  \frametitlecpp[11]{Condition variables}
   \begin{block}{How to express thread dependencies}
     \begin{itemize}
     \item Allows a thread to sleep until a given condition is satisfied
@@ -345,7 +345,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Condition variable usage}
+  \frametitlecpp[11]{Condition variable usage}
   \begin{exampleblock}{Example code}
     \begin{cppcode*}{}
       int value = -1;

--- a/talk/concurrency.tex
+++ b/talk/concurrency.tex
@@ -213,7 +213,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[11]{Mutexes and Locks}
+  \frametitlecpp[17]{Mutexes and Locks}
   \begin{block}{Concept}
     \begin{itemize}
     \item Use locks to serialize access to a non-atomic piece of code
@@ -241,7 +241,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[11]{Mutexes and Locks}
+  \frametitlecpp[17]{Mutexes and Locks}
   \begin{block}{Good practice}
     \begin{itemize}
       \item Always use \texttt{scoped\_lock} (\cpp11: \texttt{lock\_guard})
@@ -263,7 +263,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[11]{Mutexes}
+  \frametitle{Mutexes}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item Go to code/race

--- a/talk/expert.tex
+++ b/talk/expert.tex
@@ -5,7 +5,7 @@
 %http://eli.thegreenplace.net/2014/variadic-templates-in-c/
 
 \begin{frame}[fragile]
-  \frametitleii{Basic variadic template}
+  \frametitlecpp[11]{Basic variadic template}
   \begin{block}{The idea}
     \begin{itemize}
     \item a template with an arbitrary number of parameters
@@ -29,7 +29,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitleii{A couple of remarks}
+  \frametitlecpp[11]{A couple of remarks}
   \begin{block}{About performance}
     \begin{itemize}
     \item do not be afraid of recursion
@@ -47,7 +47,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Variadic templated class}
+  \frametitlecpp[11]{Variadic templated class}
   \begin{block}{The tuple example, simplified}
     \begin{cppcode*}{}
       template <typename... Ts> struct tuple {}
@@ -71,7 +71,7 @@
 
 %http://eli.thegreenplace.net/2014/perfect-forwarding-and-universal-references-in-c/
 \begin{frame}[fragile]
-  \frametitleii{The problem}
+  \frametitlecpp[11]{The problem}
   Trying to write a generic wrapper function
   \begin{cppcode*}{}
     template <typename T>
@@ -87,7 +87,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Why is it not so simple?}
+  \frametitlecpp[11]{Why is it not so simple?}
   \begin{cppcode*}{}
     template <typename T>
     void wrapper(T arg) {
@@ -101,7 +101,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Second try, second failure ?}
+  \frametitlecpp[11]{Second try, second failure ?}
   \begin{cppcode*}{}
     template <typename T>
     void wrapper(T &arg) {
@@ -119,7 +119,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{The solution : cover all cases}
+  \frametitlecpp[11]{The solution : cover all cases}
   \begin{cppcode*}{}
     template <typename T>
     void wrapper(T& arg) { func(arg); }
@@ -133,7 +133,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{The new problem : scaling to n arguments}
+  \frametitlecpp[11]{The new problem : scaling to n arguments}
   \begin{cppcode*}{}
     template <typename T1, typename T2>
     void wrapper(T1& arg1, T2& arg2)
@@ -155,7 +155,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Reference collapsing in \cpp98}
+  \frametitlecpp[11]{Reference collapsing in \cpp98}
   \begin{block}{Reference to references}
     They are forbidden in \cpp\\
     But still may happen
@@ -175,7 +175,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitleii{Reference collapsing in \cpp11}
+  \frametitlecpp[11]{Reference collapsing in \cpp11}
   \begin{block}{rvalues have been added}
     \begin{itemize}
     \item what about int\&\& \& ?
@@ -190,7 +190,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{rvalue in type-deducing context}
+  \frametitlecpp[11]{rvalue in type-deducing context}
   \begin{cppcode*}{}
     template <typename T>
     void func(T&& t) {}
@@ -214,7 +214,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{std::remove\_reference}
+  \frametitlecpp[11]{std::remove\_reference}
   Some template trickery removing reference from a type
   \begin{cppcode*}{}
     template< typename T >
@@ -234,7 +234,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{std::forward}
+  \frametitlecpp[11]{std::forward}
   Another template trickery keeping references and mapping non reference types to rvalue references
   \begin{cppcode*}{}
     template<typename T>
@@ -253,7 +253,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Perfect forwarding}
+  \frametitlecpp[11]{Perfect forwarding}
   Putting it all together
   \begin{cppcode*}{}
     template <typename... T>
@@ -284,7 +284,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Real life example}
+  \frametitlecpp[11]{Real life example}
   \begin{cppcode*}{}
     template<typename T, typename... Args>
     unique_ptr<T> make_unique(Args&&... args) {
@@ -298,7 +298,7 @@
 
 %https://jguegant.github.io/blogs/tech/sfinae-introduction.html
 \begin{frame}[fragile]
-  \frametitleii{Substitution Failure Is Not An Error (SFINAE)}
+  \frametitlecpp[11]{Substitution Failure Is Not An Error (SFINAE)}
   \begin{block}{The main idea}
     \begin{itemize}
     \item substitution replaces template parameters with the provided types or values
@@ -318,7 +318,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{decltype}
+  \frametitlecpp[11]{decltype}
   \begin{block}{The main idea}
     \begin{itemize}
     \item gives the type of the expression it will evaluate
@@ -340,7 +340,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{declval}
+  \frametitlecpp[11]{declval}
   \begin{block}{The main idea}
     \begin{itemize}
     \item gives you a ``fake reference'' to an object at compile time
@@ -364,7 +364,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{true\_type and false\_type}
+  \frametitlecpp[11]{true\_type and false\_type}
   \begin{block}{The main idea}
     \begin{itemize}
     \item encapsulate a constexpr boolean ``true'' and ``false''
@@ -382,7 +382,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Using SFINAE for introspection}
+  \frametitlecpp[11]{Using SFINAE for introspection}
   \begin{block}{The main idea}
     \begin{itemize}
     \item use a template specialization
@@ -409,7 +409,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Not so easy actually...}
+  \frametitlecpp[11]{Not so easy actually...}
   \begin{exampleblock}{Example}
     \small
     \begin{cppcode*}{}
@@ -432,7 +432,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{Using \texttt{void\_t}}
+  \frametitlecpp[17]{Using \texttt{void\_t}}
   \begin{block}{Concept}
     \begin{cppcode*}{gobble=2}
       #include <type_traits>
@@ -448,7 +448,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{Previous example using \texttt{void\_t}}
+  \frametitlecpp[17]{Previous example using \texttt{void\_t}}
     \begin{exampleblock}{Example}
       \begin{cppcode*}{}
       template <typename T, typename = void>
@@ -515,7 +515,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitleii{Back to variadic templated class}
+  \frametitlecpp[11]{Back to variadic templated class}
   \begin{block}{The tuple get method}
     \begin{cppcode*}{}
       template <size_t k, typename TUPLE>
@@ -536,7 +536,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Back to variadic templated class}
+  \frametitlecpp[11]{Back to variadic templated class}
   \begin{block}{The tuple get method}
     \begin{cppcode*}{}
       template <size_t k, typename... Ts>

--- a/talk/morelanguage.tex
+++ b/talk/morelanguage.tex
@@ -3,7 +3,7 @@
 \subsection[const]{Constness}
 
 \begin{frame}[fragile]
-  \frametitlegb{Constness}
+  \frametitlecpp[98]{Constness}
   \begin{block}{The {\it const} keyword}
     \begin{itemize}
     \item indicate that the element to the left is constant
@@ -25,7 +25,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Constness and pointers}
+  \frametitlecpp[98]{Constness and pointers}
   \begin{cppcode}
     // pointer to a constant integer
     int a = 1, b = 2;
@@ -46,7 +46,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Method constness}
+  \frametitlecpp[98]{Method constness}
   \begin{block}{The {\it const} keyword for class functions}
     \begin{itemize}
     \item indicate that the function does not modify the object
@@ -64,7 +64,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Method constness}
+  \frametitlecpp[98]{Method constness}
   \begin{block}{Constness is part of the type}
     \begin{itemize}
     \item const T and T are different types
@@ -86,7 +86,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{constness}
+  \frametitlecpp[98]{constness}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/constness
@@ -100,7 +100,7 @@
 \subsection[cstexpr]{Constant Expressions}
 
 \begin{frame}[fragile]
-  \frametitleii{Generalized Constant Expressions}
+  \frametitlecpp[11]{Generalized Constant Expressions}
   \begin{block}{Reason of being}
     \begin{itemize}
     \item compute constant expressions at compile time
@@ -119,7 +119,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Static Assertions}
+  \frametitlecpp[11]{Static Assertions}
   \begin{block}{static\_assert declaration}
     \begin{itemize}
     \item Performs compile time assertions; meaning a failed assertion stops compilation
@@ -142,7 +142,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitleii{Generalized Constant Expressions(2)}
+  \frametitlecpp[11]{Generalized Constant Expressions(2)}
    \begin{alertblock}{Few limitations in C++14 (more in C++11)}
     \begin{itemize}
     \item function's body cannot contain try-catch or static variables
@@ -163,7 +163,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Real life example}
+  \frametitlecpp[11]{Real life example}
   \begin{cppcode*}{}
     constexpr float toSI(const float v, const char unit) {
       switch (unit) {
@@ -186,7 +186,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Real life example(2)}
+  \frametitlecpp[11]{Real life example(2)}
   \begin{cppcode*}{}
     class DimLength {
       const float m_value;
@@ -208,7 +208,7 @@
 \subsection[except]{Exceptions}
 
 \begin{frame}[fragile]
-  \frametitlegb{Exceptions}
+  \frametitlecpp[98]{Exceptions}
   \begin{block}{The concept}
     \begin{itemize}
     \item exceptional event breaking linearity of the code
@@ -234,7 +234,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Exceptions}
+  \frametitlecpp[98]{Exceptions}
   \begin{block}{Rules}
     \begin{itemize}
     \item exception will skip all code until next {\it catch}
@@ -277,7 +277,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Controlling exceptions \hfill \deprecated}
+  \frametitlecpp[98]{Controlling exceptions \hfill \deprecated}
   \begin{block}{Declaring expected exceptions}
     \begin{itemize}
     \item each function can declare a set of expected exceptions
@@ -302,7 +302,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Controlling exceptions \hfill \deprecated}
+  \frametitlecpp[98]{Controlling exceptions \hfill \deprecated}
   \begin{block}{Good to know}
     \begin{itemize}
     \item The check is done at runtime, not at compile time
@@ -325,7 +325,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Deprecation of \cpp98 exceptions}
+  \frametitlecpp[11]{Deprecation of \cpp98 exceptions}
   \begin{block}{}
     After a lot of thinking and experiencing, the conclusions of the community on exception handling are :
     \begin{itemize}
@@ -351,7 +351,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{What remains}
+  \frametitlecpp[11]{What remains}
   \begin{block}{throw is dead}
     \begin{itemize}
     \item throw statements are deprecated
@@ -369,7 +369,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Full power of noexcept}
+  \frametitlecpp[11]{Full power of noexcept}
   \begin{block}{3 uses of noexcept}
     \begin{itemize}
     \item standalone
@@ -392,7 +392,7 @@
 \subsection[mv]{Move semantics}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics : the problem}
+  \frametitlecpp[11]{Move semantics : the problem}
   \begin{exampleblock}{Non efficient code}
     \begin{cppcode*}{}
       void swap(std::vector<int> &a,
@@ -417,7 +417,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics : the problem}
+  \frametitlecpp[11]{Move semantics : the problem}
   \begin{exampleblock}{Dedicated efficient code}
     \begin{cppcode*}{}
       std::vector<int> v(10000), w(10000);
@@ -437,7 +437,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics : the problem}
+  \frametitlecpp[11]{Move semantics : the problem}
   \begin{exampleblock}{Another non efficient code}
     \begin{cppcode*}{}
       std::vector<int> vrandom(unsigned int n) {
@@ -461,7 +461,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics : the problem}
+  \frametitlecpp[11]{Move semantics : the problem}
   \begin{exampleblock}{Dedicated efficient way}
     \begin{cppcode*}{}
       void vrandom(unsigned int n, std::vector<int> &v) {
@@ -481,7 +481,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics}
+  \frametitlecpp[11]{Move semantics}
   \begin{block}{The idea}
     \begin{itemize}
       \item a new type of reference : rvalue references
@@ -508,7 +508,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics}
+  \frametitlecpp[11]{Move semantics}
   \begin{block}{A few important points concerning move semantic}
     \begin{itemize}
     \item the whole STL understands move semantics
@@ -536,7 +536,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics}
+  \frametitlecpp[11]{Move semantics}
   \begin{block}{In some cases, you want to force a move}
     \begin{cppcode*}{}
       void swap(T &a, T &b) {
@@ -562,7 +562,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics : the easy way}
+  \frametitlecpp[11]{Move semantics : the easy way}
   \begin{block}{Use copy and swap idiom}
     \begin{itemize}
     \item implement an efficient swap method for your class
@@ -590,7 +590,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move semantics : the easy way}
+  \frametitlecpp[11]{Move semantics : the easy way}
   \begin{exampleblock}{Practically}
     \begin{cppcode*}{}
       class Movable {
@@ -611,7 +611,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Move Semantic}
+  \frametitlecpp[11]{Move Semantic}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/move
@@ -629,7 +629,7 @@
 \subsection[copy]{Copy elision}
 
 \begin{frame}[fragile]
-  \frametitleit{Guaranteed copy elision}
+  \frametitlecpp[17]{Guaranteed copy elision}
   \begin{block}{What is copy elision}
     \begin{cppcode*}{}
       struct Foo { ... };
@@ -648,7 +648,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{Guaranteed copy elision}
+  \frametitlecpp[17]{Guaranteed copy elision}
   Allows to write code not allowed with \cpp14 (would not compile)
   \begin{block}{One case where the guarantee is needed}
     \begin{cppcode*}{}
@@ -670,7 +670,7 @@
 \subsection[\textless{}T\textgreater]{Templates}
 
 \begin{frame}[fragile]
-  \frametitlegb{Templates}
+  \frametitlecpp[98]{Templates}
   \begin{block}{Concept}
     \begin{itemize}
     \item The \cpp way to write reusable code
@@ -695,7 +695,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Templates}
+  \frametitlecpp[98]{Templates}
   \begin{alertblock}{Warning}
     These are really like macros
     \begin{itemize}
@@ -751,7 +751,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Templates}
+  \frametitlecpp[98]{Templates}
   \begin{block}{Arguments}
     \begin{itemize}
     \item can be a class,
@@ -773,7 +773,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Templates implementation}
+  \frametitlecpp[98]{Templates implementation}
   \begin{cppcode*}{}
     template<typename KeyType=int, typename ValueType=KeyType>
     struct Map {
@@ -814,7 +814,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Templates}
+  \frametitlecpp[98]{Templates}
   \begin{block}{Specialization}
     templates can be specialized for given values of their parameter
   \end{block}
@@ -835,7 +835,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{The full power of templates}
+  \frametitlecpp[98]{The full power of templates}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/templates
@@ -854,7 +854,7 @@
 \subsection[STL]{The STL}
 
 \begin{frame}[fragile]
-  \frametitlegb{The Standard Template Library}
+  \frametitlecpp[98]{The Standard Template Library}
   \begin{block}{What it is}
     \begin{itemize}
     \item A library of standard templates
@@ -877,7 +877,7 @@
 \end{frame}
 
 \begin{frame}[fragile,label=STLcode]
-  \frametitleii{STL in practice}
+  \frametitlecpp[11]{STL in practice}
   \begin{cppcode*}{}
     #include <vector>
     #include <algorithm>
@@ -897,7 +897,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{STL's concepts}
+  \frametitlecpp[98]{STL's concepts}
   \begin{block}{containers}
     \begin{itemize}
     \item a structure containing data
@@ -920,7 +920,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{STL's concepts}
+  \frametitlecpp[98]{STL's concepts}
   \begin{block}{iterators}
     \begin{itemize}
     \item generalization of pointers
@@ -942,7 +942,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{STL's concepts}
+  \frametitlecpp[98]{STL's concepts}
   \begin{block}{algorithms}
     \begin{itemize}
     \item implementation of an algorithm working on data
@@ -967,7 +967,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{STL's concepts}
+  \frametitlecpp[98]{STL's concepts}
   \begin{block}{functions / functors}
     \begin{itemize}
       \item generic utility functions/functors
@@ -992,7 +992,7 @@
 \againframe{STLcode}
 
 \begin{frame}[fragile]
-  \frametitlegb{STL in practice using \cpp98}
+  \frametitlecpp[98]{STL in practice using \cpp98}
   \begin{cppcode*}{}
     #include <vector>
     #include <algorithm>
@@ -1014,7 +1014,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{STL and functors}
+  \frametitlecpp[98]{STL and functors}
   \begin{cppcode}
     // Finds the first element in a list that lies in
     // the range from 1 to 10.
@@ -1035,7 +1035,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Welcome to lego programming !}
+  \frametitlecpp[98]{Welcome to lego programming !}
   \begin{block}{}
     \pgfdeclareimage[height=0.5cm]{AtlasLego}{AtlasLego.jpg}
     \includegraphics[width=\linewidth]{AtlasLego}
@@ -1043,7 +1043,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Using the STL}
+  \frametitlecpp[98]{Using the STL}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/stl
@@ -1061,7 +1061,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Using the STL}
+  \frametitlecpp[98]{Using the STL}
   \begin{alertblock}{Some last warning}
     You may find the STL quite difficult to use.
     \begin{itemize}
@@ -1074,7 +1074,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Loops and auto keyword with the STL}
+  \frametitlecpp[11]{Loops and auto keyword with the STL}
   \begin{block}{Old way}
     \begin{cppcode*}{}
       std::vector<int> a = ...;
@@ -1105,7 +1105,7 @@
 \subsection{More STL}
 
 \begin{frame}[fragile]
-  \frametitleit{Some new STL types}
+  \frametitlecpp[17]{Some new STL types}
   \begin{block}{\texttt{std::optional}}
     \begin{itemize}
     \item manages an optional contained value
@@ -1130,7 +1130,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{non-member begin and end}
+  \frametitlecpp[11]{non-member begin and end}
   \begin{alertblock}{The problem in \cpp98}
     STL containers and arrays have different syntax for loop
     \vspace{-1mm}
@@ -1158,7 +1158,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{Structured Binding Declarations}
+  \frametitlecpp[17]{Structured Binding Declarations}
   Helps when using tuples as a return type.\\
   Automatically creates variables and ties them.
   \begin{alertblock}{\cpp14}
@@ -1182,7 +1182,7 @@
 \subsection[$\lambda$]{Lambdas}
 
 \begin{frame}[fragile]
-  \frametitleii{Function return type}
+  \frametitlecpp[11]{Function return type}
   \begin{block}{A new way to specify function's return type}
     \begin{cppcode*}{linenos=false}
       ReturnType fn_name(ArgType1, ArgType2);  //old
@@ -1209,7 +1209,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitleii{Lambdas}
+  \frametitlecpp[11]{Lambdas}
   \begin{block}{Definition}
     a lambda is a function with no name
   \end{block}
@@ -1230,7 +1230,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{\cpp Lambdas}
+  \frametitlecpp[11]{\cpp Lambdas}
   \begin{block}{Simplified syntax}
     \begin{cppcode*}{gobble=2}
       [] (args) -> type {
@@ -1253,7 +1253,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitleii{Capture}
+  \frametitlecpp[11]{Capture}
   \begin{block}{Python code}
     \begin{pythoncode*}{}
       increment = 3
@@ -1281,7 +1281,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Capture}
+  \frametitlecpp[11]{Capture}
   \begin{block}{Variable capture}
     \begin{itemize}
     \item external variables need to be explicitly captured
@@ -1302,7 +1302,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Default capture is by value}
+  \frametitlecpp[11]{Default capture is by value}
   \begin{exampleblock}{Code example}
     \begin{cppcode}
       int sum = 0;
@@ -1325,7 +1325,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Capture by reference}
+  \frametitlecpp[11]{Capture by reference}
   \begin{exampleblock}{Simple example}
     In order to capture by reference, add '\&' before the variable
     \begin{cppcode*}{}
@@ -1350,7 +1350,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Capture all}
+  \frametitlecpp[11]{Capture all}
   \begin{block}{by value}
     \begin{cppcode*}{linenos=false}
       [=](...) { ... };
@@ -1372,7 +1372,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Lambdas rather than functors}
+  \frametitlecpp[11]{Lambdas rather than functors}
   \begin{exampleblock}{Example}
     \begin{cppcode*}{}
       auto build_incrementer = [](int inc) {
@@ -1395,7 +1395,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{{\texttt lambda}s makes the STL usable}
+  \frametitlecpp[11]{{\texttt lambda}s makes the STL usable}
   \begin{block}{Before lambdas}
     \begin{cppcode*}{}
       struct Incrementer {
@@ -1414,7 +1414,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{{\texttt lambda}s makes the STL usable}
+  \frametitlecpp[11]{{\texttt lambda}s makes the STL usable}
   \begin{exampleblock}{With lambdas}
     \begin{cppcode*}{}
       std::vector<int> v{1, 2, 3};
@@ -1432,7 +1432,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Lambdas}
+  \frametitlecpp[11]{Lambdas}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/lambdas
@@ -1445,7 +1445,7 @@
 \subsection[RAII]{pointers and RAII}
 
 \begin{frame}[fragile]
-  \frametitlegb{Pointers : why they are error prone ?}
+  \frametitlecpp[98]{Pointers : why they are error prone ?}
   \begin{exampleblock}{They need initialization
       \hfill \onslide<2->{\textcolor{orange}{\bf Seg Fault}}}
     \begin{cppcode*}{xleftmargin=20pt}
@@ -1488,7 +1488,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{This problem exists for any resource}
+  \frametitlecpp[98]{This problem exists for any resource}
   \begin{exampleblock}{For example with a file}
     \begin{cppcode*}{}
       try {
@@ -1504,7 +1504,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitlegb{Resource Acquisition Is Initialization (RAII)}
+  \frametitlecpp[98]{Resource Acquisition Is Initialization (RAII)}
   \begin{block}{Practically}
     Use object semantic to acquire/release resources
     \begin{itemize}
@@ -1517,7 +1517,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{RAII in practice}
+  \frametitlecpp[98]{RAII in practice}
   \begin{exampleblock}{File class}
     \begin{cppcode*}{}
       class File {
@@ -1540,7 +1540,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{RAII usage}
+  \frametitlecpp[98]{RAII usage}
   \begin{exampleblock}{Usage of File class}
     \begin{cppcode*}{}
       void log_function() {
@@ -1558,7 +1558,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{std::unique\_ptr}
+  \frametitlecpp[11]{std::unique\_ptr}
   \begin{block}{an RAII pointer}
     \begin{itemize}
     \item wraps a regular pointer
@@ -1585,7 +1585,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Quiz}
+  \frametitlecpp[11]{Quiz}
   \begin{exampleblock}{}
     \begin{cppcode*}{}
       Foo *p = new Foo{};  // allocation
@@ -1611,7 +1611,7 @@ of 'std::unique_ptr<Foo>'
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleia{std::make\_unique}
+  \frametitlecpp[14]{std::make\_unique}
   \begin{block}{}
     \begin{itemize}
     \item allocates directly a unique\_ptr
@@ -1635,7 +1635,7 @@ of 'std::unique_ptr<Foo>'
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{RAII or raw pointers}
+  \frametitlecpp[11]{RAII or raw pointers}
   \begin{block}{When to use what ?}
     \begin{itemize}
     \item Always use RAII for allocations
@@ -1662,7 +1662,7 @@ of 'std::unique_ptr<Foo>'
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{unique\_ptr usage summary}
+  \frametitlecpp[11]{unique\_ptr usage summary}
   \begin{block}{It's about lifetime management}
     \begin{itemize}
     \item Use unique\_ptr in functions taking part to the lifetime management
@@ -1672,7 +1672,7 @@ of 'std::unique_ptr<Foo>'
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{shared\_ptr, make\_shared}
+  \frametitlecpp[11]{shared\_ptr, make\_shared}
   \begin{block}{shared\_ptr : a reference counting pointer}
     \begin{itemize}
     \item wraps a regular pointer like unique\_ptr
@@ -1696,7 +1696,7 @@ of 'std::unique_ptr<Foo>'
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{smart pointers}
+  \frametitlecpp[98]{smart pointers}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/smartPointers

--- a/talk/objectorientation.tex
+++ b/talk/objectorientation.tex
@@ -3,7 +3,7 @@
 \subsection[OO]{Objects and Classes}
 
 \begin{frame}[fragile]
-  \frametitlegb{What are classes and objects}
+  \frametitlecpp[98]{What are classes and objects}
   \begin{block}{Classes (or ``user-defined types'')}
     C structs on steroids
     \begin{itemize}
@@ -30,7 +30,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitlegb{My First Class}
+  \frametitlecpp[98]{My First Class}
   \begin{multicols}{2}
     \begin{cppcode*}{gobble=2}
       struct MyFirstClass {
@@ -64,7 +64,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Separating the interface}
+  \frametitlecpp[98]{Separating the interface}
   \begin{block}{Header : MyFirstClass.hpp}
     \begin{cppcode*}{}
       #pragma once
@@ -89,7 +89,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Implementing methods}
+  \frametitlecpp[98]{Implementing methods}
   \begin{block}{Standard practice}
     \begin{itemize}
     \item usually in .cpp, outside of class declaration
@@ -109,7 +109,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{{\ttfamily this} keyword}
+  \frametitlecpp[98]{{\ttfamily this} keyword}
   \begin{block}{}
     \begin{itemize}
     \item {\ttfamily this} is a hidden parameter to all class methods
@@ -129,7 +129,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Method overloading}
+  \frametitlecpp[98]{Method overloading}
   \begin{block}{The rules in \cpp}
     \begin{itemize}
     \item overloading is authorized and welcome
@@ -155,7 +155,7 @@
 \subsection[inherit]{Inheritance}
 
 \begin{frame}[fragile]
-  \frametitlegb{First inheritance}
+  \frametitlecpp[98]{First inheritance}
   \begin{multicols}{2}
     \begin{cppcode*}{gobble=2}
       struct MyFirstClass {
@@ -193,7 +193,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Managing access to class members}
+  \frametitlecpp[98]{Managing access to class members}
   \begin{block}{{\it public} \color{white} / {\it private} keywords}
     \begin{description}
       \item[private] allows access only within the class
@@ -232,7 +232,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Managing access to class members(2)}
+  \frametitlecpp[98]{Managing access to class members(2)}
   \begin{block}{Solution is {\it protected} keyword}
     Gives access to classes inheriting from base class
   \end{block}
@@ -263,7 +263,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Managing inheritance privacy}
+  \frametitlecpp[98]{Managing inheritance privacy}
   \begin{block}{Inheritance can be public, protected or private}
     It influences the privacy of inherited members for external code.\\
     The code of the class itself is not affected
@@ -288,7 +288,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Managing inheritance privacy - public}
+  \frametitlecpp[98]{Managing inheritance privacy - public}
   \begin{multicols}{2}
     \begin{tikzpicture}[node distance=3cm]
       \classbox{MyFirstClass}{
@@ -330,7 +330,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Managing inheritance privacy - protected}
+  \frametitlecpp[98]{Managing inheritance privacy - protected}
   \begin{multicols}{2}
     \begin{tikzpicture}[node distance=3cm]
       \classbox{MyFirstClass}{
@@ -372,7 +372,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Managing inheritance privacy - private}
+  \frametitlecpp[98]{Managing inheritance privacy - private}
   \begin{multicols}{2}
     \begin{tikzpicture}[node distance=3cm]
       \classbox{MyFirstClass}{
@@ -414,7 +414,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Final class}
+  \frametitlecpp[11]{Final class}
   \begin{block}{Idea}
     \begin{itemize}
     \item make sure you cannot inherit from a given class
@@ -436,7 +436,7 @@
 \subsection[construct]{Constructors/destructors}
 
 \begin{frame}[fragile]
-  \frametitlegb{Class Constructors and Destructors}
+  \frametitlecpp[98]{Class Constructors and Destructors}
   \begin{block}{Concept}
     \begin{itemize}
     \item special functions building/destroying an object
@@ -472,7 +472,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitlegb{Class Constructors and Destructors}
+  \frametitlecpp[98]{Class Constructors and Destructors}
   \begin{cppcode}
     class Vector {
     public:
@@ -494,7 +494,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Constructor and inheritance}
+  \frametitlecpp[98]{Constructor and inheritance}
   \begin{cppcode}
     struct MyFirstClass {
       int a;
@@ -515,7 +515,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Copy constructor}
+  \frametitlecpp[98]{Copy constructor}
   \begin{block}{Concept}
     \begin{itemize}
     \item special constructor called for replicating an object
@@ -543,7 +543,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Class Constructors and Destructors}
+  \frametitlecpp[98]{Class Constructors and Destructors}
   \begin{cppcode}
     class Vector {
     public:
@@ -564,7 +564,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Default Constructor}
+  \frametitlecpp[11]{Default Constructor}
   \begin{block}{Idea}
     \begin{itemize}
     \item avoid writing explicitly default constructors
@@ -588,7 +588,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Constructor delegation}
+  \frametitlecpp[11]{Constructor delegation}
   \begin{block}{Idea}
     \begin{itemize}
     \item avoid replication of code in several constructors
@@ -607,7 +607,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Constructor inheritance}
+  \frametitlecpp[11]{Constructor inheritance}
   \begin{block}{Idea}
     \begin{itemize}
     \item avoid having to re-declare parent's constructors
@@ -628,7 +628,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Member initialization}
+  \frametitlecpp[11]{Member initialization}
   \begin{block}{Idea}
     \begin{itemize}
     \item avoid redefining same default value for members n times
@@ -652,7 +652,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Calling constructors}
+  \frametitlecpp[11]{Calling constructors}
   \begin{block}{After object declaration, arguments within \{\}}
     \begin{multicols}{2}
       \begin{cppcode*}{gobble=4}
@@ -684,7 +684,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Calling constructors the old way}
+  \frametitlecpp[98]{Calling constructors the old way}
   \begin{block}{Arguments are given within (), aka \cpp98 nightmare}
     \begin{multicols}{2}
       \begin{cppcode*}{gobble=4}
@@ -716,7 +716,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Calling constructors for arrays and vectors}
+  \frametitlecpp[11]{Calling constructors for arrays and vectors}
   \begin{exampleblock}{list of items given within \{\}}
     \begin{cppcode*}{firstnumber=10}
      int ip[3]{1,2,3};
@@ -737,7 +737,7 @@
 \subsection[static]{Static members}
 
 \begin{frame}[fragile]
-  \frametitlegb{Static members}
+  \frametitlecpp[98]{Static members}
   \begin{block}{Concept}
     \begin{itemize}
     \item members attached to a class rather than to an object
@@ -761,7 +761,7 @@
 \subsection[new]{Allocating objects}
 
 \begin{frame}[fragile]
-  \frametitlegb{Process memory organization}
+  \frametitlecpp[98]{Process memory organization}
   \begin{block}{4 main areas}
     \begin{description}
     \item[the code segment] for the code of the executable
@@ -787,7 +787,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{The Stack}
+  \frametitlecpp[98]{The Stack}
   \begin{block}{Main characteristics}
     \begin{itemize}
     \item allocation on the stack stays valid for the duration of the current scope.
@@ -799,7 +799,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Object allocation on the stack}
+  \frametitlecpp[98]{Object allocation on the stack}
   \begin{block}{On the stack}
     \begin{itemize}
     \item objects are created when declared (constructor called)
@@ -820,7 +820,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{The Heap}
+  \frametitlecpp[98]{The Heap}
   \begin{block}{Main characteristics}
     \begin{itemize}
     \item Allocated memory stays allocated until it is specifically deallocated
@@ -834,7 +834,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Object allocation on the heap}
+  \frametitlecpp[98]{Object allocation on the heap}
   \begin{block}{On the heap}
     \begin{itemize}
     \item object are created by calling {\it new} (constructor is called)
@@ -858,7 +858,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Array allocation on the heap}
+  \frametitlecpp[98]{Array allocation on the heap}
   \begin{block}{Arrays on the heap}
     \begin{itemize}
     \item arrays of objects are created by calling {\it new[]} \\
@@ -880,7 +880,7 @@
 \subsection[advOO]{Advanced OO}
 
 \begin{frame}[fragile]
-  \frametitlegb{Polymorphism}
+  \frametitlecpp[98]{Polymorphism}
   \begin{block}{the concept}
     \begin{itemize}
     \item objects actually have multiple types simultaneously
@@ -914,7 +914,7 @@
 
 
 \begin{frame}[fragile]
-  \frametitlegb{Inheritance privacy and polymorphism}
+  \frametitlecpp[98]{Inheritance privacy and polymorphism}
   \begin{block}{Only public inheritance is visible to code outside the class}
     \begin{itemize}
     \item private and protected are not
@@ -947,7 +947,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Method overriding}
+  \frametitlecpp[98]{Method overriding}
   \begin{block}{the problem}
     \begin{itemize}
     \item a given method of the parent can be overridden in a child
@@ -979,7 +979,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Virtual methods}
+  \frametitlecpp[98]{Virtual methods}
   \begin{block}{the concept}
     \begin{itemize}
     \item methods can be declared \mintinline{cpp}{virtual}
@@ -1039,7 +1039,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Virtual methods - implications}
+  \frametitlecpp[11]{Virtual methods - implications}
   \begin{block}{Mechanics}
     \begin{itemize}
     \item virtual methods are deduced at run time
@@ -1063,7 +1063,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{{\texttt override} keyword}
+  \frametitlecpp[11]{{\texttt override} keyword}
   \begin{block}{Principle}
     \begin{itemize}
     \item when overriding a virtual method
@@ -1083,7 +1083,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{Why was {\texttt override} keyword introduced ?}
+  \frametitlecpp[11]{Why was {\texttt override} keyword introduced ?}
   To detect the mistake in the following code :
   \begin{block}{Without {\texttt override} (\cpp98)}
     \begin{cppcode}
@@ -1102,7 +1102,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleii{{\texttt final} keyword}
+  \frametitlecpp[11]{{\texttt final} keyword}
   \begin{block}{Idea}
     \begin{itemize}
     \item make sure you cannot override further a given virtual method
@@ -1125,7 +1125,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Pure Virtual methods}
+  \frametitlecpp[98]{Pure Virtual methods}
   \begin{block}{Concept}
     \begin{itemize}
     \item methods that exist but are not implemented
@@ -1163,7 +1163,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Pure Abstract Class aka Interface}
+  \frametitlecpp[98]{Pure Abstract Class aka Interface}
   \begin{block}{Definition of pure abstract class}
     \begin{itemize}
     \item a class that has
@@ -1191,7 +1191,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Overriding overloaded methods}
+  \frametitlecpp[98]{Overriding overloaded methods}
   \begin{block}{Concept}
     \begin{itemize}
     \item overriding an overloaded method will hide the others
@@ -1213,7 +1213,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Polymorphism}
+  \frametitlecpp[98]{Polymorphism}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/polymorphism
@@ -1228,7 +1228,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Multiple Inheritance}
+  \frametitlecpp[98]{Multiple Inheritance}
   \begin{block}{Concept}
     \begin{itemize}
     \item one class can inherit from multiple parents
@@ -1258,7 +1258,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{The diamond shape}
+  \frametitlecpp[98]{The diamond shape}
   \begin{block}{Definition}
     \begin{itemize}
     \item situation when one class inherits several times from a given grand parent
@@ -1284,7 +1284,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Virtual inheritance}
+  \frametitlecpp[98]{Virtual inheritance}
   \begin{block}{Solution}
     \begin{itemize}
     \item inheritance can be {\it virtual} or not
@@ -1323,7 +1323,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Multiple inheritance advice}
+  \frametitlecpp[98]{Multiple inheritance advice}
   \begin{block}{Do not use multiple inheritance}
     \begin{itemize}
     \item Except for inheriting from interfaces
@@ -1340,7 +1340,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Virtual inheritance}
+  \frametitlecpp[98]{Virtual inheritance}
   \begin{alertblock}{Exercise Time}
     \begin{itemize}
     \item go to code/virtual\_inheritance
@@ -1354,7 +1354,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Virtual inheritance}
+  \frametitlecpp[98]{Virtual inheritance}
   \begin{alertblock}{Warning}
     in case of virtual inheritance it is the most derived class that calls the virtual base class's constructor
   \end{alertblock}
@@ -1364,7 +1364,7 @@
 \subsection[Op]{Operators}
 
 \begin{frame}[fragile]
-  \frametitlegb{Operators' example}
+  \frametitlecpp[98]{Operators' example}
   \begin{cppcode}
     struct Complex {
       float m_real, m_imaginary;
@@ -1381,7 +1381,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitlegb{Operators}
+  \frametitlecpp[98]{Operators}
   \begin{block}{Definition for operators of a class}
     \begin{itemize}
     \item implemented as a regular method
@@ -1406,7 +1406,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Why to have non-member operators ?}
+  \frametitlecpp[98]{Why to have non-member operators ?}
   \begin{block}{Symmetry}
     \begin{cppcode}
       struct Complex {
@@ -1429,7 +1429,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Other reason to have non-member operators ?}
+  \frametitlecpp[98]{Other reason to have non-member operators ?}
   \begin{block}{Extending existing classes}
     \begin{cppcode}
       struct Complex {
@@ -1452,7 +1452,7 @@
 \subsection[()]{Functors}
 
 \begin{frame}[fragile]
-  \frametitlegb{Functors}
+  \frametitlecpp[98]{Functors}
   \begin{block}{Concept}
     \begin{itemize}
     \item a class that implements the () operator
@@ -1476,7 +1476,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{Functors}
+  \frametitlecpp[98]{Functors}
   \begin{block}{Typical usage}
     \begin{itemize}
     \item pass a function to another one
@@ -1502,7 +1502,7 @@
 \subsection[ADL]{Name Lookups}
 
 \begin{frame}[fragile]
-  \frametitlegb{Basics of name lookup}
+  \frametitlecpp[98]{Basics of name lookup}
   \begin{exampleblock}{Example code}
     \begin{cppcode}
       std::cout << std::endl;
@@ -1527,7 +1527,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitlegb{Unqualified name lookup and ADL}
+  \frametitlecpp[98]{Unqualified name lookup and ADL}
   \begin{block}{Ordered list of scopes (simplified)}
     \begin{itemize}
     \item file (only for global level usage)
@@ -1547,7 +1547,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{ADL consequences (1)}
+  \frametitlecpp[98]{ADL consequences (1)}
   \begin{block}{Use standalone/non-member functions}
     When a method is not accessing the private part of a class, make it a function in the same namespace
     \vspace{-1mm}
@@ -1589,7 +1589,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitleit{ADL consequences (2)}
+  \frametitlecpp[17]{ADL consequences (2)}
   \begin{block}{Prefer nested namespaces to \texttt{using}}
     Don't write :
     \begin{cppcode}
@@ -1607,7 +1607,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlegb{ADL consequences (3)}
+  \frametitlecpp[98]{ADL consequences (3)}
   \begin{block}{Customization points and \texttt{using}}
     \begin{columns}[t]
       \begin{column}{.35\textwidth}


### PR DESCRIPTION
On first sight, it's easy to miss that `\frametitleii{}` expands to C++98.
Here, I define
```tex
\frametitlecpp[98, 11, 14, ...]{Title}
```
which should be easier to read.

I can offer to run text replacements on all `frametitlexx`.

This could make things such as [#55](https://github.com/hsf-training/cpluspluscourse/pull/55#issuecomment-948361548) a bit easier.