### PR TITLE
Colour URLs in hyperref package.

### DIFF
--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -270,3 +270,7 @@
     \tableofcontents[sectionstyle=show/hide,subsectionstyle=show/shaded/hide]
   \end{frame}
 }
+
+\hypersetup{
+  urlcolor={\color{blue!50!white}}
+}


### PR DESCRIPTION
See https://github.com/hsf-training/cpluspluscourse/pull/93#discussion_r813401045

The colour is only for URLs. Intra-document links should not be affected (to be checked when CI finishes).