### PR TITLE
add slides on HSF training

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -46,6 +46,22 @@
   \end{block}
 \end{frame}
 
+
+\begin{frame}
+  \frametitle{More courses}
+  \begin{block}{The HSF Software Training Center}
+    A set of course modules on more software engineering aspects prepared from within the HEP community
+    \begin{itemize}
+      \item Unix shell
+      \item Python
+      \item Version control (git, gitlab, github)
+      \item ...
+    \end{itemize}
+    {\small \url{https://hepsoftwarefoundation.org/training/curriculum.html}}
+  \end{block}
+
+\end{frame}
+
 \begin{frame}
   \frametitle{Outline}
   \begin{multicols}{2}


### PR DESCRIPTION
add a slide on HSF trainings. The only reasonable place I found was right after the intro slide ... 