### PR TITLE
Two slides about explicit unary constructors.

### DIFF
--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -151,7 +151,7 @@
   \frametitlecpp[98]{Explicit unary constructor}
   \begin{block}{Concept}
     \begin{itemize}
-      \item The keyword {\it explicit} forbid such implicit conversion.
+      \item The keyword \mintinline{cpp}{explicit} forbids such implicit conversions.
       \item It is recommended to use it systematically, except in special cases.
     \end{itemize}
   \end{block}

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -64,12 +64,12 @@
     struct MyFirstClass {
       int a;
       MyFirstClass();
-      explicit MyFirstClass(int a);
+      MyFirstClass(int a);
     };
     struct MySecondClass : MyFirstClass {
       int b;
       MySecondClass();
-      explicit MySecondClass(int b);
+      MySecondClass(int b);
       MySecondClass(int a, int b);
     };
     MySecondClass() : MyFirstClass(), b(0) {}

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -64,12 +64,12 @@
     struct MyFirstClass {
       int a;
       MyFirstClass();
-      MyFirstClass(int a);
+      explicit MyFirstClass(int a);
     };
     struct MySecondClass : MyFirstClass {
       int b;
       MySecondClass();
-      MySecondClass(int b);
+      explicit MySecondClass(int b);
       MySecondClass(int a, int b);
     };
     MySecondClass() : MyFirstClass(), b(0) {}
@@ -125,6 +125,44 @@
       std::copy(other.data, other.data + len, data);
     }
     Vector::~Vector() { delete[] data; }
+  \end{cppcode}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[98]{Explicit unary constructor}
+  \begin{block}{Concept}
+    \begin{itemize}
+    \item A constructor with a single non-default parameter can be used by the compiler for an implicit conversion.
+    \item In the code below, {\it 3} is implicitly converted into a {\it Vector} of size {\it 3}, which may be unexpected by the developer.
+    \end{itemize}
+  \end{block}
+  \begin{cppcode}
+    print( const Vector & v ) {}
+      std::cout<<"printing v elements..."<<std::endl ;
+    }
+
+    int main {
+      print(3) ;
+    };
+  \end{cppcode}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[98]{Explicit unary constructor}
+  \begin{block}{Concept}
+    \begin{itemize}
+      \item The keyword {\it explicit} forbid such implicit conversion.
+      \item It is recommended to use it systematically, except in special cases.
+    \end{itemize}
+  \end{block}
+  \begin{cppcode}
+    class Vector {
+    public:
+      explicit Vector(int n);
+      Vector(const Vector &other);
+      ~Vector();
+      ...
+    };
   \end{cppcode}
 \end{frame}
 

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -137,8 +137,8 @@
     \end{itemize}
   \end{block}
   \begin{cppcode}
-    print( const Vector & v ) {}
-      std::cout<<"printing v elements..."<<std::endl ;
+    void print( const Vector & v )
+      std::cout<<"printing v elements...\n";
     }
 
     int main {


### PR DESCRIPTION
I chose to put them in the constructors section, at the end of C++98 slides, and before C++11 ones. One key question is : should we correct all the subsequent slides with `explicit` ? One one hand, this would be consistent with the advice to use `explicit` by default. On the other hand, it woul dput "noise"in the examples. What do you think ?