### PR TITLE
Correct signedness of plain char

### DIFF
--- a/talk/basicconcepts/coresyntax.tex
+++ b/talk/basicconcepts/coresyntax.tex
@@ -47,32 +47,32 @@
   \begin{cppcode}
     bool b = true;            // boolean, true or false
 
-    char c = 'a';             // 8 bits ASCII char
+    char c = 'a';             // 8 bit ASCII char
     char* s = "a C string";   // array of chars ended by \0
     string t = "a C++ string";// class provided by the STL
 
-    char c = -3;              // 8 bits integer (signed or unsigned)
-    unsigned char c = 4;      // 8 bits unsigned integer
+    char c = -3;              // 8 bit integer (signed or unsigned)
+    unsigned char c = 4;      // 8 bit unsigned integer
 
-    short int s = -444;       // 16 bits signed integer
-    unsigned short s = 444;   // 16 bits unsigned integer
+    short int s = -444;       // 16 bit signed integer
+    unsigned short s = 444;   // 16 bit unsigned integer
     short s = -444;           // int is optional
   \end{cppcode}
 \end{frame}
 \begin{frame}[fragile]
   \frametitlecpp[98]{Basic types(2)}
   \begin{cppcode}
-    int i = -123456;          // 32 bits signed integer
-    unsigned int i = 1234567; // 32 bits signed integer
+    int i = -123456;          // 32 bit signed integer
+    unsigned int i = 1234567; // 32 bit signed integer
 
     long l = 0L               // 32 or 64 bits (ptr size)
     unsigned long l = 0UL;    // 32 or 64 bits (ptr size)
 
-    long long ll = 0LL;       // 64 bits signed integer
-    unsigned long long l = 0ULL; // 64 bits unsigned integer
+    long long ll = 0LL;       // 64 bit signed integer
+    unsigned long long l = 0ULL; // 64 bit unsigned integer
 
-    float f = 1.23f;          // 32 (23+7+1) bits float
-    double d = 1.23E34;       // 64 (52+11+1) bits float
+    float f = 1.23f;          // 32 (23+7+1) bit float
+    double d = 1.23E34;       // 64 (52+11+1) bit float
   \end{cppcode}
 \end{frame}
 

--- a/talk/basicconcepts/coresyntax.tex
+++ b/talk/basicconcepts/coresyntax.tex
@@ -51,7 +51,7 @@
     char* s = "a C string";   // array of chars ended by \0
     string t = "a C++ string";// class provided by the STL
 
-    char c = -3;              // 8 bits signed integer
+    char c = -3;              // 8 bits integer (signed or unsigned)
     unsigned char c = 4;      // 8 bits unsigned integer
 
     short int s = -444;       // 16 bits signed integer

--- a/talk/basicconcepts/coresyntax.tex
+++ b/talk/basicconcepts/coresyntax.tex
@@ -51,7 +51,7 @@
     char* s = "a C string";   // array of chars ended by \0
     string t = "a C++ string";// class provided by the STL
 
-    char c = -3;              // 8 bit integer (signed or unsigned)
+    char c = -3;              // 8 bit integer (signed or not)
     unsigned char c = 4;      // 8 bit unsigned integer
 
     short int s = -444;       // 16 bit signed integer


### PR DESCRIPTION
A plain `char` type in C++ has an implementation defined sign. e.g., x86 is signed, ARM is unsigned.

See <https://en.cppreference.com/w/cpp/language/types>.

Note that also in English one says "an N bit integer" not "an N bit**s** integer. "bit" here becomes an adjective, so it doesn't matter than there are multiple of them (cf. "an integer of 8 bit**s**", where the plural is correct).