### PR TITLE
Build the exercises in the CI, master branch (2022.03.14.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -69,9 +69,9 @@ jobs:
           - NAME: "polymorphism"
             BUILD_DEFAULT: true
             BUILD_SOLUTION: true
-          - NAME: "python"
-            BUILD_DEFAULT: true
-            BUILD_SOLUTION: false
+#          - NAME: "python"
+#            BUILD_DEFAULT: true
+#            BUILD_SOLUTION: false
           - NAME: "race"
             BUILD_DEFAULT: true
             BUILD_SOLUTION: true

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,160 @@
+
+# Name for this "action".
+name: Build Exercises
+
+# Perform the builds on every push and pull request.
+on: [ push, pull_request ]
+
+# All the different build/test jobs.
+jobs:
+
+  # Native (non-container) build jobs.
+  native:
+
+    # The "build matrix".
+    strategy:
+      matrix:
+        EXERCISE:
+          - NAME: "asan"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "atomic"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "callgrind"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "condition_variable"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "constness"
+            BUILD_DEFAULT: false
+            BUILD_SOLUTION: false
+          - NAME: "control"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "cppcheck"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "debug"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "functions"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "helgrind"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "hello"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: false
+          - NAME: "lambdas"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "loopsRefsAuto"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "memcheck"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "modern_oo"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "move"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "operators"
+            BUILD_DEFAULT: false
+            BUILD_SOLUTION: true
+          - NAME: "polymorphism"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "python"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: false
+          - NAME: "race"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "smartPointers"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "stl"
+            BUILD_DEFAULT: false
+            BUILD_SOLUTION: true
+          - NAME: "templates"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "valgrind"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+          - NAME: "virtual_inheritance"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: true
+        PLATFORM:
+          - OS: "ubuntu-latest"
+            GENERATOR: -G "Unix Makefiles"
+          - OS: "macos-latest"
+            GENERATOR: -G "Xcode"
+          - OS: "windows-latest"
+            GENERATOR:
+        exclude:
+          - EXERCISE:
+              NAME: "helgrind"
+              BUILD_DEFAULT: true
+              BUILD_SOLUTION: true
+            PLATFORM:
+              OS: "windows-latest"
+              GENERATOR:
+          - EXERCISE:
+              NAME: "python"
+              BUILD_DEFAULT: true
+              BUILD_SOLUTION: false
+            PLATFORM:
+              OS: "windows-latest"
+              GENERATOR:
+          - EXERCISE:
+              NAME: "stl"
+              BUILD_DEFAULT: false
+              BUILD_SOLUTION: true
+            PLATFORM:
+              OS: "windows-latest"
+              GENERATOR:
+          - EXERCISE:
+              NAME: "stl"
+              BUILD_DEFAULT: false
+              BUILD_SOLUTION: true
+            PLATFORM:
+              OS: "macos-latest"
+              GENERATOR: -G "Xcode"
+
+    # The system to run on.
+    runs-on: ${{ matrix.PLATFORM.OS }}
+
+    # The build/test steps to execute.
+    steps:
+    # Use a standard checkout of the code.
+    - uses: actions/checkout@v2
+    # Run the CMake configuration.
+    - name: CMake Configure
+      run: cmake -S ${{ github.workspace }}/code/${{ matrix.EXERCISE.NAME }}
+                 -B build
+                 ${{ matrix.PLATFORM.GENERATOR }}
+    # Perform the build of the "main exercise" with CMake.
+    - name: CMake Build Main
+      run: cmake --build build
+      if: matrix.EXERCISE.BUILD_DEFAULT
+    # Perform the build of the "solution" with CMake.
+    - name: CMake Build Solution
+      run: cmake --build build --target solution
+      if: matrix.EXERCISE.BUILD_SOLUTION
+    # Perform the build of the "main exercise" with GNU Make.
+    - name: GNU Make Build Main
+      run: make -C ${{ github.workspace }}/code/${{ matrix.EXERCISE.NAME }}
+      if: ${{ matrix.PLATFORM.OS != 'windows-latest' &&
+              matrix.EXERCISE.BUILD_DEFAULT }}
+    # Perform the build of the "solution" with GNU Make.
+    - name: GNU Make Build Solution
+      run: make -C ${{ github.workspace }}/code/${{ matrix.EXERCISE.NAME }}
+                solution
+      if: ${{ matrix.PLATFORM.OS != 'windows-latest' &&
+              matrix.EXERCISE.BUILD_SOLUTION }}

--- a/code/lambdas/CMakeLists.txt
+++ b/code/lambdas/CMakeLists.txt
@@ -3,12 +3,12 @@
 cmake_minimum_required( VERSION 3.1 )
 project( lambdas LANGUAGES CXX )
 
-# This example only works warning-free in C++11 mode with MSVC and Clang.
-set( CMAKE_CXX_STANDARD 11 )
-
 # Set up the compilation environment.
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../CompilerSettings.cmake" )
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../SolutionTarget.cmake" )
+
+# This example only works warning-free in C++11 mode with MSVC and Clang.
+set( CMAKE_CXX_STANDARD 11 )
 
 # Create the user's executable.
 add_executable( lambdas_randomize "Complex.hpp" "randomize.cpp" )

--- a/code/loopsRefsAuto/CMakeLists.txt
+++ b/code/loopsRefsAuto/CMakeLists.txt
@@ -5,6 +5,7 @@ project( loopsRefsAuto LANGUAGES CXX )
 
 # Set up the compilation environment.
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../CompilerSettings.cmake" )
+include( "${CMAKE_CURRENT_SOURCE_DIR}/../SolutionTarget.cmake" )
 
 # Create the user's executable.
 add_executable( loopsRefsAuto "loopsRefsAuto.cpp" )

--- a/code/polymorphism/Makefile
+++ b/code/polymorphism/Makefile
@@ -5,10 +5,10 @@ clean:
 	rm -f *o *so trypoly *~ trypoly.sol
 
 libpoly.so: Polygons.cpp Polygons.hpp
-	$(CXX) -Wsuggest-override -g -Wall -Wextra -shared -fPIC -o $@ $<
+	$(CXX) -std=c++11 -Wsuggest-override -g -Wall -Wextra -shared -fPIC -o $@ $<
 
 trypoly : trypoly.cpp libpoly.so
-	$(CXX) -Wsuggest-override -g -Wall -Wextra -o $@ $^
+	$(CXX) -std=c++11 -Wsuggest-override -g -Wall -Wextra -o $@ $^
 
 trypoly.sol : solution/trypoly.sol.cpp libpoly.so
-	$(CXX) -g -Wall -Wextra -I. -o $@ $^
+	$(CXX) -std=c++11 -g -Wall -Wextra -I. -o $@ $^

--- a/code/templates/Makefile
+++ b/code/templates/Makefile
@@ -5,7 +5,7 @@ clean:
 	rm -f *o *so playwithsort *~ playwithsort.sol
 
 playwithsort : playwithsort.cpp OrderedVector.hpp Complex.hpp
-	$(CXX) -g -O0 -Wall -Wextra -o $@ $<
+	$(CXX) -std=c++11 -g -O0 -Wall -Wextra -o $@ $<
 
 playwithsort.sol : solution/playwithsort.sol.cpp solution/OrderedVector.sol.hpp Complex.hpp
-	$(CXX) -g -O0 -Wall -Wextra -I. -o $@ $<
+	$(CXX) -std=c++11 -g -O0 -Wall -Wextra -I. -o $@ $<


### PR DESCRIPTION
Taught the CI how to build the exercises on every available (native) platform.

This also revealed problems that I myself made in #119, and which @chavid made in #121. Highlighting that we really desperately need to test these things in the CI. :thinking:

Note that the configuration came out a bit more complicated than I would've hoped. The "matrix" ended up being quite a bit more elaborate than ideal. :frowning: But this was the best that I could come up with after some experimentation.

Note that we should probably also add a test with @chavid's preferred Docker image at one point. (It was you who was looking after running the exercises with Docker, right?) Those we'll need to set up separately. That's why I chose the "native" name for these jobs, following the convention that I used in some other projects as well. (Where the containerised jobs would have the name "container" in the CI configuration.)

Pinging @sponce, @roiser, @hageboeck and @bernhardmgruber.

Those of you not doing builds on macOS or Windows regularly may want to peek at some of the build outputs. :wink: