### PR TITLE
Fix addresses in memorystack.

### DIFF
--- a/talk/basicconcepts/arrayspointers.tex
+++ b/talk/basicconcepts/arrayspointers.tex
@@ -50,7 +50,7 @@ int l = *pak;
   \columnbreak
     \onslide<2->{
       \begin{tikzpicture}
-        \memorystack[size x=3cm,word size=1,nb blocks=11]
+        \memorystack[size x=3cm,word size=1,block size=4,nb blocks=11]
         \onslide<2-> {\memorypush{i = 4}}
         \onslide<3-> {\memorypushpointer[pi =]{1}}
         \onslide<4-> {\memorypush{j = 5}}

--- a/talk/basicconcepts/functions.tex
+++ b/talk/basicconcepts/functions.tex
@@ -151,7 +151,7 @@ changeSS2(s);
     \columnbreak
     \null \vfill
     \begin{tikzpicture}
-      \memorystack[word size=1, nb blocks=3, size x=3cm]
+      \memorystack[word size=1, block size=4, nb blocks=3, size x=3cm]
       \onslide<2-6> {
         \memorypush{s.a = 1}
       }

--- a/talk/basicconcepts/scopesnamespaces.tex
+++ b/talk/basicconcepts/scopesnamespaces.tex
@@ -54,7 +54,7 @@ int a = 1;
     \columnbreak
 
     \begin{tikzpicture}
-      \memorystack[word size=1, nb blocks=5, size x = 0.5\columnwidth]
+      \memorystack[word size=1, block size=4, nb blocks=5, size x = 0.5\columnwidth]
       \onslide<1-> {
         \memorypush{a = 1}
       }

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -127,7 +127,7 @@
   word size/.initial=4,
   block size/.initial=1,
   nb blocks/.initial=8,
-  base address/.initial=12348,
+  base address/.initial=12288,
   color/.initial=black,
   addresses/.initial=1
 }
@@ -165,7 +165,7 @@
             [rectangle,minimum width=\stacksizex,minimum height=\stacksizey] {};
     }
     \ifnum1=\displayaddrs\relax
-      \pgfmathparse{\n*\blocksize*\stackwordsize+\stackbaseaddr}
+      \pgfmathparse{(\n-1)*\blocksize*\stackwordsize+\stackbaseaddr}
       \pgfmathdectoBase\hexversion{\pgfmathresult}{16}
       \draw node at (\stacksizex,\n*\stacksizey-\stacksizey/2) [right=2pt]
             {0x\hexversion};
@@ -230,7 +230,7 @@
     base address/.get=\stackbaseaddr,
     block size/.get=\blocksize,
   }
-  \pgfmathparse{#2*\stackwordsize*\blocksize+\stackbaseaddr}
+  \pgfmathparse{(#2-1)*\stackwordsize*\blocksize+\stackbaseaddr}
   \pgfmathdectoBase\hexaddress{\pgfmathresult}{16}
   \memorypushvalue{\arabic{memorystackindex}}{1}{#1 0x\hexaddress}
   \draw[\stackcolor!80,->] (stack\arabic{memorystackindex}-1.west) .. controls +(left:1) and +(left:1) .. (stack#2-1.west);

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -125,8 +125,9 @@
   size x/.initial=4cm,
   size y/.initial=.5cm,
   word size/.initial=4,
+  block size/.initial=1,
   nb blocks/.initial=8,
-  base address/.initial=12351,
+  base address/.initial=12348,
   color/.initial=black,
   addresses/.initial=1
 }
@@ -139,6 +140,7 @@
     size x/.get=\stacksizex,
     size y/.get=\stacksizey,
     word size/.get=\stackwordsize,
+    block size/.get=\blocksize,
     nb blocks/.get=\stacknbblocks,
     base address/.get=\stackbaseaddr,
     color/.get=\stackcolor,
@@ -163,7 +165,7 @@
             [rectangle,minimum width=\stacksizex,minimum height=\stacksizey] {};
     }
     \ifnum1=\displayaddrs\relax
-      \pgfmathparse{\n*\stackwordsize+\stackbaseaddr}
+      \pgfmathparse{\n*\blocksize*\stackwordsize+\stackbaseaddr}
       \pgfmathdectoBase\hexversion{\pgfmathresult}{16}
       \draw node at (\stacksizex,\n*\stacksizey-\stacksizey/2) [right=2pt]
             {0x\hexversion};
@@ -225,9 +227,10 @@
 \newcommand\memorypushpointer[2][]{
   \memorystackset{
     word size/.get=\stackwordsize,
-    base address/.get=\stackbaseaddr
+    base address/.get=\stackbaseaddr,
+    block size/.get=\blocksize,
   }
-  \pgfmathparse{#2*\stackwordsize+\stackbaseaddr}
+  \pgfmathparse{#2*\stackwordsize*\blocksize+\stackbaseaddr}
   \pgfmathdectoBase\hexaddress{\pgfmathresult}{16}
   \memorypushvalue{\arabic{memorystackindex}}{1}{#1 0x\hexaddress}
   \draw[\stackcolor!80,->] (stack\arabic{memorystackindex}-1.west) .. controls +(left:1) and +(left:1) .. (stack#2-1.west);


### PR DESCRIPTION
As @amadio pointed out, the stacks are showing wrong addresses when
setting word size == 1, but pushing integers on the stack.

There's still a slightly ugly thing: pointers are 32 bits in the current version. I think we can live with that, though. Only to be mentioned if somebody asks.