### PR TITLE
Python CI Update, master branch (2022.03.15.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -69,9 +69,9 @@ jobs:
           - NAME: "polymorphism"
             BUILD_DEFAULT: true
             BUILD_SOLUTION: true
-#          - NAME: "python"
-#            BUILD_DEFAULT: true
-#            BUILD_SOLUTION: false
+          - NAME: "python"
+            BUILD_DEFAULT: true
+            BUILD_SOLUTION: false
           - NAME: "race"
             BUILD_DEFAULT: true
             BUILD_SOLUTION: true
@@ -134,6 +134,10 @@ jobs:
     steps:
     # Use a standard checkout of the code.
     - uses: actions/checkout@v2
+    # Make sure that Python 3 is available to the build.
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
     # Run the CMake configuration.
     - name: CMake Configure
       run: cmake -S ${{ github.workspace }}/code/${{ matrix.EXERCISE.NAME }}

--- a/code/python/Makefile
+++ b/code/python/Makefile
@@ -1,18 +1,12 @@
-PYTHON_VERSION=$(word 2, $(shell python3 --version))
-PYTHON_LOCATION=$(dir $(shell which python3))
-PYTHON_MAJOR=$(word 1,$(subst ., ,$(PYTHON_VERSION)))
-PYTHON_MINOR=$(word 2,$(subst ., ,$(PYTHON_VERSION)))
-PYTHON_INCLUDE_BASE=$(PYTHON_LOCATION)../include/python$(PYTHON_MAJOR).$(PYTHON_MINOR)
-PYTHON_INCLUDE=$(if $(wildcard $(PYTHON_INCLUDE_BASE)m/Python.h),$(PYTHON_INCLUDE_BASE)m, $(PYTHON_INCLUDE_BASE))
 
 all: mandel.so libmandelc.so
 solution: mandel.so libmandelc.so
 
 mandel.so:mandel_module.o libmandel.so
-	${CXX} -shared $^ -o $@
+	${CXX} -shared -Wl,-undefined,dynamic_lookup $^ -o $@ `python3-config --ldflags`
 
 mandel_module.o:mandel_module.cpp
-	${CXX} -pthread -O3 -Wall -std=c++14 -fPIC -I. -I$(PYTHON_INCLUDE) -c $< -o $@
+	${CXX} -pthread -O3 -Wall -std=c++14 -fPIC -I. `python3-config --cflags` -c $< -o $@
 
 libmandelc.so:mandel_cwrapper.o libmandel.so
 	${CXX} -shared $^ -o $@
@@ -25,6 +19,3 @@ libmandel.so:mandel.cpp Complex.hpp
 
 clean:
 	rm -rf *.o *.so *~ *pyc *pyo *svg
-
-debug:
-	@echo Python minor version: $(PYTHON_INCLUDE)


### PR DESCRIPTION
Enabled the build of the Python exercise in the CI. While at the same time greatly simplifying the `Makefile` of the exercise.

This is a follow-up from #129. Pinging @sponce.