### PR TITLE
Use shuffle and reduce

### DIFF
--- a/code/smartPointers/CMakeLists.txt
+++ b/code/smartPointers/CMakeLists.txt
@@ -3,6 +3,9 @@
 cmake_minimum_required( VERSION 3.1 )
 project( smartPointers LANGUAGES CXX )
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set up the compilation environment.
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../CompilerSettings.cmake" )
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../SolutionTarget.cmake" )

--- a/code/smartPointers/smartPointers.cpp
+++ b/code/smartPointers/smartPointers.cpp
@@ -34,7 +34,7 @@ double sumEntries(const double* data, std::size_t size) {
     if (size > 200)
         throw std::invalid_argument("I only want to sum 200 numbers or less.");
 
-    return std::accumulate(data, data + size, 0);
+    return std::reduce(data, data + size, 0);
 }
 
 // Often, data are owned by one entity, and only used by others. Fix the leak.

--- a/code/smartPointers/solution/smartPointers.sol.cpp
+++ b/code/smartPointers/solution/smartPointers.sol.cpp
@@ -35,7 +35,7 @@ double sumEntries(const double* data, std::size_t size) {
     if (size > 200)
         throw std::invalid_argument("I only want to sum 200 numbers or less.");
 
-    return std::accumulate(data, data + size, 0.);
+    return std::reduce(data, data + size, 0.);
 }
 
 // Often, data are owned by one entity, and only used by others. Fix the leak.

--- a/code/stl/CMakeLists.txt
+++ b/code/stl/CMakeLists.txt
@@ -3,6 +3,9 @@
 cmake_minimum_required( VERSION 3.1 )
 project( stl LANGUAGES CXX )
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set up the compilation environment.
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../CompilerSettings.cmake" )
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../SolutionTarget.cmake" )

--- a/code/stl/Makefile
+++ b/code/stl/Makefile
@@ -5,10 +5,10 @@ clean:
 	rm -f *o randomize *~ randomize.sol randomize.nostl
 
 randomize : randomize.cpp
-	${CXX} -g -O0 -Wall -Wextra -L. -o $@ $<
+	${CXX} -std=c++17 -g -O0 -Wall -Wextra -L. -o $@ $<
 
 randomize.nostl : randomize.nostl.cpp
-	${CXX} -g -O0 -Wall -Wextra -L. -o $@ $<
+	${CXX} -std=c++17 -g -O0 -Wall -Wextra -L. -o $@ $<
 
 randomize.sol : solution/randomize.sol.cpp
-	${CXX} -g -O0 -Wall -Wextra -I. -L. -o $@ $<
+	${CXX} -std=c++17 -g -O0 -Wall -Wextra -I. -L. -o $@ $<

--- a/code/stl/randomize.cpp
+++ b/code/stl/randomize.cpp
@@ -1,12 +1,11 @@
 #include <iostream>
-#include <math.h>
 #include <algorithm>
 #include <vector>
 #include <numeric>
+#include <random>
 #include "Complex.hpp"
 
 using namespace std;
-using namespace __gnu_cxx;
 
 template<typename T>
 struct Generator {
@@ -20,7 +19,7 @@ void compute(int len, T initial, T step) {
 
     // fill and randomize v
     generate(, , Generator...);
-    random_shuffle(...);
+    shuffle(..., std::default_random_engine{});
 
     // compute differences
     adjacent_difference(...);

--- a/code/stl/solution/randomize.sol.cpp
+++ b/code/stl/solution/randomize.sol.cpp
@@ -1,12 +1,11 @@
 #include <iostream>
-#include <math.h>
 #include <algorithm>
 #include <vector>
 #include <numeric>
+#include <random>
 #include "Complex.hpp"
 
 using namespace std;
-using namespace __gnu_cxx;
 
 template<typename T>
 struct Generator {
@@ -31,14 +30,14 @@ void compute(int len, T initial, T step) {
 
     // fill and randomize v
     generate(v.begin(), v.end(), Generator<T>(initial, step));
-    random_shuffle(v.begin(), v.end());
+    shuffle(v.begin(), v.end(), std::default_random_engine{});
 
     // compute differences
     adjacent_difference(v.begin(), v.end(), diffs.begin());
 
     // compute standard deviation of it
-    T sum = accumulate(diffs.begin()+1, diffs.end(), T());
-    T sumsq = accumulate(diffs.begin()+1, diffs.end(), T(), sumsquare<T>());
+    T sum = reduce(diffs.begin()+1, diffs.end(), T());
+    T sumsq = reduce(diffs.begin()+1, diffs.end(), T(), sumsquare<T>());
     T mean = sum/len;
     T variance = sumsq/len - mean*mean;
 


### PR DESCRIPTION
This PR replaces `random_shuffle` (dropped in C++17) by `shuffle` and `accumulate` by `reduce`.

This is not necessary for the exercises tomorrow.