### PR TITLE
Also advertise lldb and gdb-oneapi

### DIFF
--- a/talk/tools/debugging.tex
+++ b/talk/tools/debugging.tex
@@ -22,9 +22,9 @@
     \item[\href{http://www.sourceware.org/gdb/}{\beamergotobutton{gdb}}]
       THE main player
     \item[\href{http://lldb.llvm.org/}{\beamergotobutton{lldb}}]
-      the debugger coming with clang, still young
-    \item[\href{http://software.intel.com/en-us/articles/idb-linux}{\beamergotobutton{idb}}]
-      the intel debugger, proprietary
+      the debugger coming with clang/LLVM
+    \item[\href{https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/top.html}{\beamergotobutton{gdb-oneapi}}]
+      the Intel OneAPI debugger
     \end{description}
     They usually can be integrated into your IDE
   \end{block}
@@ -61,7 +61,7 @@
     \begin{itemize}
     \item go to code/debug
     \item compile, run, see the crash
-    \item run it in gdb
+    \item run it in gdb (or lldb on newer MacOS)
     \item inspect backtrace, variables
     \item find problem and fix bug
     \item try stepping, breakpoints


### PR DESCRIPTION
Some students yesterday could not run or install gdb on their MacOS. It seems lldb is the only debugger available there.
Also the Intel debugger seems old/deprecated. The new one should be `gdb-oneapi`. But we could also discuss to drop it completely from the slides.