### PR TITLE
Produce stable links for latest version of the slides

### DIFF
--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,0 +1,18 @@
+name: GitHub Actions Demo
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."
+

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: clone download-slides
+      - name: clone download
         run: |
-          git clone -b download-slides https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download-slides
+          git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:
@@ -20,16 +20,16 @@ jobs:
       - name: Commit to repo
         run: |
           set -x
-          mkdir download-slides/talk
-          cp talk/C++Course.pdf download-slides/talk
-          cd download-slides
+          mkdir download/talk
+          cp talk/C++Course.pdf download/talk
+          cd download
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git add -f talk/C++Course.pdf
           if (git diff --quiet) || (git diff --staged --quiet)
           then
             git commit -m "Update C++Course.pdf"
-            git push origin download-slides
+            git push origin download
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -9,15 +9,13 @@ jobs:
   setup-download-repo:
     runs-on: ubuntu-latest
     steps:
-      # - name: Setup repository
-      #   uses: actions/checkout@v2
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
           cd download
           git checkout download
           git reset --hard emptyrepo
-          git push --force # https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+          git push --force
   produce-slides:
     needs: setup-download-repo
     runs-on: ubuntu-latest

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,5 +1,9 @@
 name: Produce a stable download link for the slides
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '55 23 * * 0'
 
 jobs:
   produce-slides:
@@ -27,7 +31,7 @@ jobs:
       - name: Commit to repository
         run: |
           set -x
-          mkdir download/talk
+          mkdir -p download/talk
           cp talk/C++Course.pdf "download/talk/C++Course_${{ matrix.version }}"
           cd download
           git config --global user.email "action@github.com"

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -23,12 +23,13 @@ jobs:
           cd download-slides/talk
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git add C++-Course.pdf
-          if (git diff --quiet) || (git diff --staged --quiet)
-          then
-            git commit -m "Update C++-Course.pdf"
-            git push origin download-slides
-          else
-            echo "No changes to commit"
-          fi
-          git push
+          git status
+          # git add C++-Course.pdf
+          # if (git diff --quiet) || (git diff --staged --quiet)
+          # then
+          #   git commit -m "Update C++-Course.pdf"
+          #   git push origin download-slides
+          # else
+          #   echo "No changes to commit"
+          # fi
+          # git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emptyrepo
           git checkout -B download emptyrepotag
-          git push -set-upstream origin download
+          git push --set-upstream origin download
   produce-slides:
     needs: setup-download-repo
     runs-on: ubuntu-latest

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Reset download branch based on emptyrepo branch
         run: |
-          git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emptyrepo
-          git checkout -B download 7e24b39ec580559e4dfa6c75cbc65401cb8b317e # emptyrepotag
-          git push --set-upstream origin download
+          git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+          git reset --hard emptyrepo
+          git push --force https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
   produce-slides:
     needs: setup-download-repo
     runs-on: ubuntu-latest

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -9,8 +9,8 @@ jobs:
   setup-download-repo:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup repository
-        uses: actions/checkout@v2
+      # - name: Setup repository
+      #   uses: actions/checkout@v2
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -23,7 +23,7 @@ jobs:
           cd download-slides
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git add talk/C++-Course.pdf
+          git add C++-Course.pdf
           if (git diff --quiet) || (git diff --staged --quiet)
           then
             git commit -m "Update C++-Course.pdf"

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -x
           mkdir -p download/talk
-          cp talk/C++Course.pdf "download/talk/C++Course_${{ matrix.version }}"
+          cp talk/C++Course.pdf "download/talk/C++Course_${{ matrix.version }}.pdf"
           cd download
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,18 +1,34 @@
-name: GitHub Actions Demo
+name: Produce a stable download link for the slides
 on: [push]
+
 jobs:
-  Explore-GitHub-Actions:
+  produce-slides:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
+      - uses: actions/checkout@v2
+      - name: clone download-slides
         run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
-
+          git clone -b download-slides https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download-slides
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: C++Course.tex
+          latexmk_use_xelatex: true
+          args: -f -pdf -interaction=nonstopmode -shell-escape
+          # working_directory: talk
+          extra_system_packages: "py-pygments"
+      - name: Commit to repo
+        run: |
+          set -x
+          cd download-slides
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add C++-Course.pdf
+          if (git diff --quiet) || (git diff --staged --quiet)
+          then
+            git commit -m "Update C++-Course.pdf"
+            git push origin download-slides
+          else
+            echo "No changes to commit"
+          fi
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -14,10 +14,8 @@ jobs:
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
-          pwd
-          ls -l
           cd download
-          git fetch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git
+          # git fetch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git
           git branch -av
           git reset --hard emptyrepo
           git push --force https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -16,6 +16,8 @@ jobs:
           git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
           cd download
           # git fetch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git
+          git checkout emptyrepo
+          git checkout download
           git branch -av
           git reset --hard emptyrepo
           git push --force https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,4 +1,4 @@
-name: Produce a stable download link for the slides
+name: Produce a stable download link for the slides  
 on:
   push:
   pull_request:

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emptyrepo
-          git checkout -B download emptyrepotag
+          git checkout -B download 7e24b39ec580559e4dfa6c75cbc65401cb8b317e # emptyrepotag
           git push --set-upstream origin download
   produce-slides:
     needs: setup-download-repo

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emptyrepo
-          git checkout -B download emptyrepo
+          git checkout -B download emptyrepotag
           git push -set-upstream origin download
   produce-slides:
     needs: setup-download-repo

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Commit to repo
         run: |
           set -x
-          cd download-slides
+          cd download-slides/talk
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git add C++-Course.pdf

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -9,6 +9,8 @@ jobs:
   setup-download-repo:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup repository
+        uses: actions/checkout@v2
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emptyrepo

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -15,11 +15,13 @@ jobs:
           root_file: C++Course.tex
           latexmk_use_xelatex: true
           args: -f -pdf -interaction=nonstopmode -shell-escape
-          working_directory: download-slides/talk
+          working_directory: talk
           extra_system_packages: "py-pygments"
       - name: Commit to repo
         run: |
           set -x
+          mkdir download-slides/talk
+          cp talk/C++Course.pdf download-slides/talk
           cd download-slides
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
@@ -31,4 +33,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push 
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -44,4 +44,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push
+          git push 

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -23,10 +23,10 @@ jobs:
           cd download-slides
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git add -f talk/C++-Course.pdf
+          git add -f talk/C++Course.pdf
           if (git diff --quiet) || (git diff --staged --quiet)
           then
-            git commit -m "Update C++-Course.pdf"
+            git commit -m "Update C++Course.pdf"
             git push origin download-slides
           else
             echo "No changes to commit"

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -33,4 +33,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push
+          git push 

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -9,20 +9,18 @@ jobs:
       - name: clone download-slides
         run: |
           git clone -b download-slides https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download-slides
-          pwd
-          ls -l 
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:
           root_file: C++Course.tex
           latexmk_use_xelatex: true
           args: -f -pdf -interaction=nonstopmode -shell-escape
-          working_directory: talk
+          working_directory: download-slides/talk
           extra_system_packages: "py-pygments"
       - name: Commit to repo
         run: |
           set -x
-          cd download-slides/talk
+          cd download-slides
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git status

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -9,6 +9,8 @@ jobs:
       - name: clone download-slides
         run: |
           git clone -b download-slides https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download-slides
+          pwd
+          ls -l 
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,14 +1,18 @@
 name: Produce a stable download link for the slides
-on: [push]
+on: [push, pull_request]
 
 jobs:
   produce-slides:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ essentials, full ]
     steps:
-      - uses: actions/checkout@v2
-      - name: clone download
-        run: |
-          git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+      - name: Setup repository
+        uses: actions/checkout@v2
+      - name: Setup essentials course
+        if: matrix.version == 'essentials'
+        run: echo '\setboolean{onlybasics}{true}' > talk/onlybasics.tex
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:
@@ -17,20 +21,23 @@ jobs:
           args: -f -pdf -interaction=nonstopmode -shell-escape
           working_directory: talk
           extra_system_packages: "py-pygments"
-      - name: Commit to repo
+      - name: Clone download
+        run: |
+          git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+      - name: Commit to repository
         run: |
           set -x
           mkdir download/talk
-          cp talk/C++Course.pdf download/talk
+          cp talk/C++Course.pdf "download/talk/C++Course_${{ matrix.version }}"
           cd download
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git add -f talk/C++Course.pdf
+          git add -f "talk/C++Course_${{ matrix.version }}.pdf"
           if (git diff --quiet) || (git diff --staged --quiet)
           then
-            git commit -m "Update C++Course.pdf"
+            git commit -m "Update C++Course_${{ matrix.version }}.pdf"
             git push origin download
           else
             echo "No changes to commit"
           fi
-          git push 
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -31,4 +31,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push
+          git push  

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+          pwd
+          ls -l
+          cd download
           git fetch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git
           git branch -av
           git reset --hard emptyrepo

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -23,13 +23,12 @@ jobs:
           cd download-slides
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git status
-          # git add C++-Course.pdf
-          # if (git diff --quiet) || (git diff --staged --quiet)
-          # then
-          #   git commit -m "Update C++-Course.pdf"
-          #   git push origin download-slides
-          # else
-          #   echo "No changes to commit"
-          # fi
-          # git push
+          git add -f talk/C++-Course.pdf
+          if (git diff --quiet) || (git diff --staged --quiet)
+          then
+            git commit -m "Update C++-Course.pdf"
+            git push origin download-slides
+          else
+            echo "No changes to commit"
+          fi
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -31,4 +31,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push
+          git push 

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Reset download branch based on emptyrepo branch
         run: |
-          git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emtpyrepo
+          git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emptyrepo
           git checkout -B download emptyrepo
           git push -set-upstream origin download
   produce-slides:

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -13,14 +13,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Reset download branch based on emptyrepo branch
         run: |
-          git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+          git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
           cd download
-          # git fetch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git
-          git checkout emptyrepo
           git checkout download
-          git branch -av
           git reset --hard emptyrepo
-          git push --force https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+          git push --force # https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
   produce-slides:
     needs: setup-download-repo
     runs-on: ubuntu-latest

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,4 +1,4 @@
-name: Produce a stable download link for the slides  
+name: Produce a stable download link for the slides
 on:
   push:
   pull_request:
@@ -6,7 +6,16 @@ on:
     - cron: '55 23 * * 0'
 
 jobs:
+  setup-download-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reset download branch based on emptyrepo branch
+        run: |
+          git clone -b emptyrepo https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git emtpyrepo
+          git checkout -B download emptyrepo
+          git push -set-upstream origin download
   produce-slides:
+    needs: setup-download-repo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,4 +53,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push 
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -15,7 +15,7 @@ jobs:
           root_file: C++Course.tex
           latexmk_use_xelatex: true
           args: -f -pdf -interaction=nonstopmode -shell-escape
-          # working_directory: talk
+          working_directory: talk
           extra_system_packages: "py-pygments"
       - name: Commit to repo
         run: |
@@ -23,7 +23,7 @@ jobs:
           cd download-slides
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git add C++-Course.pdf
+          git add talk/C++-Course.pdf
           if (git diff --quiet) || (git diff --staged --quiet)
           then
             git commit -m "Update C++-Course.pdf"
@@ -31,4 +31,4 @@ jobs:
           else
             echo "No changes to commit"
           fi
-          git push  
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Reset download branch based on emptyrepo branch
         run: |
           git clone -b download https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
+          git fetch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git
+          git branch -av
           git reset --hard emptyrepo
           git push --force https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git download
   produce-slides:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ C++Course.out
 C++Course.snm
 C++Course.toc
 C++Course.vrb
+C++Course.xdv
 C++Course.pdf
 C++Course*.vrb
 C++Course.fdb_latexmk


### PR DESCRIPTION
Runs a github action (worflow/slides.yaml) which will produce the two versions of the slides (essentials & full) and commit them to the "download" branch. The github action should run on every commit, pull request and on Sunday 23:55. 

The result should be stable links to the slides, if not mistaken those should be

https://github.com/hsf-training/cpluspluscourse/blob/download/talk/C%2B%2BCourse_essentials.pdf 
https://github.com/hsf-training/cpluspluscourse/blob/download/talk/C%2B%2BCourse_full.pdf

and the base directory 

https://github.com/hsf-training/cpluspluscourse/tree/download/talk

The PR also contains the ignore of xdv files in the .gitignore. 

Fixes #171 