### PR TITLE
Add allcontributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "hageboeck",
+      "name": "Stephan Hageboeck",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16205615?v=4",
+      "profile": "https://github.com/hageboeck",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -100,6 +100,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "klieret",
+      "name": "Kilian Lieret",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13602468?v=4",
+      "profile": "https://www.lieret.net/",
+      "contributions": [
+        "infra"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -64,6 +64,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "theanalyst",
+      "name": "Abhishek L",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1433152?v=4",
+      "profile": "http://includeio.stream/",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -91,6 +91,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "bcouturi",
+      "name": "bcouturi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7208288?v=4",
+      "profile": "https://github.com/bcouturi",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -46,6 +46,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "roiser",
+      "name": "Stefan Roiser",
+      "avatar_url": "https://avatars.githubusercontent.com/u/807095?v=4",
+      "profile": "https://github.com/roiser",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -55,6 +55,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "sponce",
+      "name": "Sebastien Ponce",
+      "avatar_url": "https://avatars.githubusercontent.com/u/731524?v=4",
+      "profile": "https://github.com/sponce",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -9,6 +9,16 @@
   "imageSize": 100,
   "commit": true,
   "commitConvention": "gitmoji",
-  "contributors": [],
+  "contributors": [
+    {
+      "login": "chavid",
+      "name": "David Chamont",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4421289?v=4",
+      "profile": "https://github.com/chavid",
+      "contributions": [
+        "content"
+      ]
+    }
+  ],
   "contributorsPerLine": 7
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -73,6 +73,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "graeme-a-stewart",
+      "name": "Graeme A Stewart",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8511620?v=4",
+      "profile": "https://github.com/graeme-a-stewart",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,6 +3,7 @@
   "projectOwner": "hsf-training",
   "repoType": "github",
   "repoHost": "https://github.com",
+  "contributorsSortAlphabetically": true,
   "files": [
     "README.md"
   ],

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -82,6 +82,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "krasznaa",
+      "name": "Attila Krasznahorkay",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30694331?v=4",
+      "profile": "https://github.com/krasznaa",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -27,6 +27,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "bernhardmgruber",
+      "name": "Bernhard Manfred Gruber",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1224051?v=4",
+      "profile": "https://github.com/bernhardmgruber",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -37,6 +37,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "eguiraud",
+      "name": "Enrico Guiraud",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10999034?v=4",
+      "profile": "https://github.com/eguiraud",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,14 @@
+{
+  "projectName": "cpluspluscourse",
+  "projectOwner": "hsf-training",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "gitmoji",
+  "contributors": [],
+  "contributorsPerLine": 7
+}

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
 callgrind.out.*
+
+# just for the allcontributors cli installation...
+package-lock.json
+package.json
+node_modules/**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -75,6 +75,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
+    <td align="center"><a href="http://includeio.stream/"><img src="https://avatars.githubusercontent.com/u/1433152?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Abhishek L</b></sub></a><br /><a href="#content-theanalyst" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -78,6 +78,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -81,9 +81,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/graeme-a-stewart"><img src="https://avatars.githubusercontent.com/u/8511620?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Graeme A Stewart</b></sub></a><br /><a href="#content-graeme-a-stewart" title="Content">🖋</a></td>
-    <td align="center"><a href="https://github.com/sponce"><img src="https://avatars.githubusercontent.com/u/731524?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastien Ponce</b></sub></a><br /><a href="#content-sponce" title="Content">🖋</a></td>
+    <td align="center"><a href="https://www.lieret.net/"><img src="https://avatars.githubusercontent.com/u/13602468?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kilian Lieret</b></sub></a><br /><a href="#infra-klieret" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
   </tr>
   <tr>
+    <td align="center"><a href="https://github.com/sponce"><img src="https://avatars.githubusercontent.com/u/731524?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastien Ponce</b></sub></a><br /><a href="#content-sponce" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/bcouturi"><img src="https://avatars.githubusercontent.com/u/7208288?v=4?s=100" width="100px;" alt=""/><br /><sub><b>bcouturi</b></sub></a><br /><a href="#content-bcouturi" title="Content">🖋</a></td>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -76,14 +76,15 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="http://includeio.stream/"><img src="https://avatars.githubusercontent.com/u/1433152?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Abhishek L</b></sub></a><br /><a href="#content-theanalyst" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/krasznaa"><img src="https://avatars.githubusercontent.com/u/30694331?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Attila Krasznahorkay</b></sub></a><br /><a href="#content-krasznaa" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/graeme-a-stewart"><img src="https://avatars.githubusercontent.com/u/8511620?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Graeme A Stewart</b></sub></a><br /><a href="#content-graeme-a-stewart" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/sponce"><img src="https://avatars.githubusercontent.com/u/731524?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastien Ponce</b></sub></a><br /><a href="#content-sponce" title="Content">🖋</a></td>
-    <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
   </tr>
   <tr>
+    <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -75,9 +75,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
-    <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -79,8 +79,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/graeme-a-stewart"><img src="https://avatars.githubusercontent.com/u/8511620?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Graeme A Stewart</b></sub></a><br /><a href="#content-graeme-a-stewart" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/sponce"><img src="https://avatars.githubusercontent.com/u/731524?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastien Ponce</b></sub></a><br /><a href="#content-sponce" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
+  </tr>
+  <tr>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -78,6 +78,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/eguiraud"><img src="https://avatars.githubusercontent.com/u/10999034?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Enrico Guiraud</b></sub></a><br /><a href="#content-eguiraud" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/sponce"><img src="https://avatars.githubusercontent.com/u/731524?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastien Ponce</b></sub></a><br /><a href="#content-sponce" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # C++ course
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/hsf-training/cpluspluscourse/master.svg)](https://results.pre-commit.ci/latest/github/hsf-training/cpluspluscourse/master)
@@ -62,3 +65,16 @@ cmake ..
 make
 make solution
 ```
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -77,6 +77,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/bernhardmgruber"><img src="https://avatars.githubusercontent.com/u/1224051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bernhard Manfred Gruber</b></sub></a><br /><a href="#content-bernhardmgruber" title="Content">🖋</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -73,8 +73,15 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
+  </tr>
+</table>
+
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -86,6 +86,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://github.com/roiser"><img src="https://avatars.githubusercontent.com/u/807095?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Roiser</b></sub></a><br /><a href="#content-roiser" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/bcouturi"><img src="https://avatars.githubusercontent.com/u/7208288?v=4?s=100" width="100px;" alt=""/><br /><sub><b>bcouturi</b></sub></a><br /><a href="#content-bcouturi" title="Content">🖋</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ course
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![gh actions](https://github.com/hsf-training/cpluspluscourse/actions/workflows/workflow.yml/badge.svg)](https://github.com/hsf-training/cpluspluscourse/actions)
@@ -76,6 +76,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="https://github.com/chavid"><img src="https://avatars.githubusercontent.com/u/4421289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Chamont</b></sub></a><br /><a href="#content-chavid" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/hageboeck"><img src="https://avatars.githubusercontent.com/u/16205615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hageboeck</b></sub></a><br /><a href="#content-hageboeck" title="Content">🖋</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
This adds all contributors to the readme. Closes #54 
I've added everyone but me for `content` now, but I know that some others have also contributed to the infrastructure etc., so you can update that if you want,.


Let's squash the commits.

New people can be added by just commenting somewhere as described [here](https://allcontributors.org/docs/en/bot/overview)