### PR TITLE
Add missing virtual

### DIFF
--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -345,12 +345,12 @@
   \end{block}
   \begin{cppcode*}{gobble=0}
     struct BaseClass {
-      int foo(std::string);
-      int foo(int);
+      virtual int foo(std::string);
+      virtual int foo(int);
     };
     struct DerivedClass : BaseClass {
       using BaseClass::foo;
-      int foo(std::string);
+      int foo(std::string) override;
     };
     DerivedClass dc;
     dc.foo(4);      // error if no using


### PR DESCRIPTION
This slide was meant to show a scenario where a member function is
overriden. Without virtual this was not the case.

Fixes: #161