### PR TITLE
Add exercises for header units and modules

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -2,7 +2,7 @@ compile: *.tex
 	pdflatex -shell-escape $<
 	pdflatex -shell-escape $<
 
-TESTDIRS = callgrind cppcheck control hello move python smartPointers templates virtual_inheritance \
+TESTDIRS = callgrind cppcheck header_units control hello move python smartPointers templates virtual_inheritance \
 	   debug helgrind lambdas memcheck polymorphism race stl valgrind
 NOCOMPILETESTDIRS = constness
 

--- a/code/Makefile
+++ b/code/Makefile
@@ -2,7 +2,7 @@ compile: *.tex
 	pdflatex -shell-escape $<
 	pdflatex -shell-escape $<
 
-TESTDIRS = callgrind cppcheck header_units control hello move python smartPointers templates virtual_inheritance \
+TESTDIRS = callgrind cppcheck header_units control hello modules move python smartPointers templates virtual_inheritance \
 	   debug helgrind lambdas memcheck polymorphism race stl valgrind
 NOCOMPILETESTDIRS = constness
 

--- a/code/header_units/Complex.hpp
+++ b/code/header_units/Complex.hpp
@@ -1,0 +1,110 @@
+#include <ostream>
+#include <cmath>
+
+template <typename T=float>
+class Complex_t {
+public:
+    Complex_t() = default;
+    Complex_t(T r, T i) : m_r(r), m_i(i) {}
+
+    T real() const { return m_r; }
+    T imaginary() const { return m_i; }
+
+    T norm_sqr() const {
+        return m_r * m_r + m_i * m_i;
+    }
+
+    T norm() const {
+        return std::sqrt(norm_sqr());
+    }
+
+    Complex_t& operator+=(const Complex_t& other) {
+        m_r += other.m_r;
+        m_i += other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator-=(const Complex_t& other) {
+        m_r -= other.m_r;
+        m_i -= other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator*=(const Complex_t& other) {
+        const auto r = m_r * other.m_r - m_i * other.m_i;
+        const auto i = m_r * other.m_i + m_i * other.m_r;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator*=(T factor) {
+        m_r *= factor;
+        m_i *= factor;
+        return *this;
+    }
+
+    Complex_t& operator/=(const Complex_t& other) {
+        const T ns = other.norm_sqr();
+        const auto r = (m_r * other.m_r + m_i * other.m_i) / ns;
+        const auto i = (m_i * other.m_r - m_r * other.m_i) / ns;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator/=(T divisor) {
+        m_r /= divisor;
+        m_i /= divisor;
+        return *this;
+    }
+
+    friend Complex_t operator+(Complex_t a, const Complex_t& b) {
+        return a += b;
+    }
+
+    friend Complex_t operator-(Complex_t a, const Complex_t& b) {
+        return a -= b;
+    }
+
+    friend Complex_t operator*(Complex_t a, const Complex_t& b) {
+        return a *= b;
+    }
+
+    friend Complex_t operator*(Complex_t c, T factor) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator*(T factor, Complex_t c) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator/(Complex_t a, Complex_t b) {
+        return a /= b;
+    }
+
+    friend Complex_t operator/(Complex_t c, T divisor) {
+        return c /= divisor;
+    }
+
+    friend Complex_t operator/(T dividend, const Complex_t& c) {
+        return Complex_t(dividend, 0) / c;
+    }
+
+    friend bool operator==(const Complex_t& a, const Complex_t& b) {
+        return a.m_r == b.m_r && a.m_i == b.m_i;
+    }
+
+    friend bool operator<(const Complex_t& a, const Complex_t& b) {
+        return a.norm_sqr() < b.norm_sqr();
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const Complex_t<T>& c) {
+        return os << "(" << c.real() << ", " << c.imaginary() << ")";
+    }
+
+private:
+    T m_r{}, m_i{};
+};
+
+using Complex = Complex_t<>;

--- a/code/header_units/Makefile
+++ b/code/header_units/Makefile
@@ -1,0 +1,14 @@
+all: header_units
+solution: header_units.sol
+
+clean:
+	rm -rf *.o header_units gcm.cache solution/header_units solution/*.o solution/gcm.cache
+
+main.o: main.cpp Complex.hpp
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ -c $<
+
+header_units : main.o
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ $^
+
+header_units.sol:
+	$(MAKE) -C solution header_units

--- a/code/header_units/README.md
+++ b/code/header_units/README.md
@@ -1,0 +1,9 @@
+
+## Instructions
+
+* convert the `#include "Complex.hpp"` to a header unit import
+  * you will need to edit the Makefile and add a new target to precompile `Complex.hpp`
+* convert the standard library includes in `randomize.cpp` to header unit imports
+  * you will need to precompile the standard library headers in your Makefile
+  * with g++-11 and g++-12 you cannot yet precompile `<iostream>` and `<ostream>`, so keep those as a regular includes
+* below g++-12 you will get a linker error when building incrementally, so run `make clean` before each build

--- a/code/header_units/main.cpp
+++ b/code/header_units/main.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <numeric>
+#include <random>
+#include "Complex.hpp"
+
+// The code below here should not need to change !!
+
+template<typename T>
+void compute(int len, T initial, T step) {
+    // allocate vectors
+    std::vector<T> v(len+1), diffs(len+1);
+
+    // fill and randomize v
+    std::generate(v.begin(), v.end(), [value = initial, step]() mutable {
+        const T cur = value;
+        value += step;
+        return cur;
+    });
+    std::shuffle(v.begin(), v.end(), std::default_random_engine{});
+
+    // compute differences
+    std::adjacent_difference(v.begin(), v.end(), diffs.begin());
+
+    // compute standard deviation of it
+    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
+    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
+                                [](const T& s, const T& a) { return s + a * a; });
+    const T mean = sum/len;
+    const T variance = sumsq/len - mean*mean;
+
+    std::cout << "Range = [" << initial << ", " << step*len << "]\n"
+              << "Mean = " << mean << '\n'
+              << "Variance = " << variance << '\n';
+}
+
+int main() {
+    compute(1000, 0.0, 7.0);
+    compute(1000, Complex(0,0), Complex(1,2));
+}

--- a/code/header_units/solution/Complex.hpp
+++ b/code/header_units/solution/Complex.hpp
@@ -1,0 +1,110 @@
+#include <ostream>
+#include <cmath>
+
+template <typename T=float>
+class Complex_t {
+public:
+    Complex_t() = default;
+    Complex_t(T r, T i) : m_r(r), m_i(i) {}
+
+    T real() const { return m_r; }
+    T imaginary() const { return m_i; }
+
+    T norm_sqr() const {
+        return m_r * m_r + m_i * m_i;
+    }
+
+    T norm() const {
+        return std::sqrt(norm_sqr());
+    }
+
+    Complex_t& operator+=(const Complex_t& other) {
+        m_r += other.m_r;
+        m_i += other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator-=(const Complex_t& other) {
+        m_r -= other.m_r;
+        m_i -= other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator*=(const Complex_t& other) {
+        const auto r = m_r * other.m_r - m_i * other.m_i;
+        const auto i = m_r * other.m_i + m_i * other.m_r;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator*=(T factor) {
+        m_r *= factor;
+        m_i *= factor;
+        return *this;
+    }
+
+    Complex_t& operator/=(const Complex_t& other) {
+        const T ns = other.norm_sqr();
+        const auto r = (m_r * other.m_r + m_i * other.m_i) / ns;
+        const auto i = (m_i * other.m_r - m_r * other.m_i) / ns;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator/=(T divisor) {
+        m_r /= divisor;
+        m_i /= divisor;
+        return *this;
+    }
+
+    friend Complex_t operator+(Complex_t a, const Complex_t& b) {
+        return a += b;
+    }
+
+    friend Complex_t operator-(Complex_t a, const Complex_t& b) {
+        return a -= b;
+    }
+
+    friend Complex_t operator*(Complex_t a, const Complex_t& b) {
+        return a *= b;
+    }
+
+    friend Complex_t operator*(Complex_t c, T factor) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator*(T factor, Complex_t c) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator/(Complex_t a, Complex_t b) {
+        return a /= b;
+    }
+
+    friend Complex_t operator/(Complex_t c, T divisor) {
+        return c /= divisor;
+    }
+
+    friend Complex_t operator/(T dividend, const Complex_t& c) {
+        return Complex_t(dividend, 0) / c;
+    }
+
+    friend bool operator==(const Complex_t& a, const Complex_t& b) {
+        return a.m_r == b.m_r && a.m_i == b.m_i;
+    }
+
+    friend bool operator<(const Complex_t& a, const Complex_t& b) {
+        return a.norm_sqr() < b.norm_sqr();
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const Complex_t<T>& c) {
+        return os << "(" << c.real() << ", " << c.imaginary() << ")";
+    }
+
+private:
+    T m_r{}, m_i{};
+};
+
+using Complex = Complex_t<>;

--- a/code/header_units/solution/Makefile
+++ b/code/header_units/solution/Makefile
@@ -1,0 +1,16 @@
+all: header_units
+
+clean:
+	rm -rf *.o header_units gcm.cache
+
+algorithm numeric random vector:
+	${CXX} -std=c++20 -fmodules-ts -x c++-system-header $@
+
+Complex_header_unit: Complex.hpp
+	${CXX} -std=c++20 -g -O0 -Wall -Wextra -fmodules-ts -x c++-header $<
+
+main.o: main.cpp Complex_header_unit algorithm numeric random vector
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ -c $<
+
+header_units: main.o
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ $^

--- a/code/header_units/solution/main.cpp
+++ b/code/header_units/solution/main.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+import <algorithm>;
+import <vector>;
+import <numeric>;
+import <random>;
+import "Complex.hpp";
+
+template<typename T>
+void compute(int len, T initial, T step) {
+    // allocate vectors
+    std::vector<T> v(len+1), diffs(len+1);
+
+    // fill and randomize v
+    std::generate(v.begin(), v.end(), [value = initial, step]() mutable {
+        const T cur = value;
+        value += step;
+        return cur;
+    });
+    std::shuffle(v.begin(), v.end(), std::default_random_engine{});
+
+    // compute differences
+    std::adjacent_difference(v.begin(), v.end(), diffs.begin());
+
+    // compute standard deviation of it
+    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
+    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
+                                [](const T& s, const T& a) { return s + a * a; });
+    const T mean = sum/len;
+    const T variance = sumsq/len - mean*mean;
+
+    std::cout << "Range = [" << initial << ", " << step*len << "]\n"
+              << "Mean = " << mean << '\n'
+              << "Variance = " << variance << '\n';
+}
+
+int main() {
+    compute(1000, 0.0, 7.0);
+    compute(1000, Complex(0,0), Complex(1,2));
+}

--- a/code/modules/Complex.hpp
+++ b/code/modules/Complex.hpp
@@ -1,0 +1,110 @@
+#include <ostream>
+#include <cmath>
+
+template <typename T=float>
+class Complex_t {
+public:
+    Complex_t() = default;
+    Complex_t(T r, T i) : m_r(r), m_i(i) {}
+
+    T real() const { return m_r; }
+    T imaginary() const { return m_i; }
+
+    T norm_sqr() const {
+        return m_r * m_r + m_i * m_i;
+    }
+
+    T norm() const {
+        return std::sqrt(norm_sqr());
+    }
+
+    Complex_t& operator+=(const Complex_t& other) {
+        m_r += other.m_r;
+        m_i += other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator-=(const Complex_t& other) {
+        m_r -= other.m_r;
+        m_i -= other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator*=(const Complex_t& other) {
+        const auto r = m_r * other.m_r - m_i * other.m_i;
+        const auto i = m_r * other.m_i + m_i * other.m_r;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator*=(T factor) {
+        m_r *= factor;
+        m_i *= factor;
+        return *this;
+    }
+
+    Complex_t& operator/=(const Complex_t& other) {
+        const T ns = other.norm_sqr();
+        const auto r = (m_r * other.m_r + m_i * other.m_i) / ns;
+        const auto i = (m_i * other.m_r - m_r * other.m_i) / ns;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator/=(T divisor) {
+        m_r /= divisor;
+        m_i /= divisor;
+        return *this;
+    }
+
+    friend Complex_t operator+(Complex_t a, const Complex_t& b) {
+        return a += b;
+    }
+
+    friend Complex_t operator-(Complex_t a, const Complex_t& b) {
+        return a -= b;
+    }
+
+    friend Complex_t operator*(Complex_t a, const Complex_t& b) {
+        return a *= b;
+    }
+
+    friend Complex_t operator*(Complex_t c, T factor) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator*(T factor, Complex_t c) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator/(Complex_t a, Complex_t b) {
+        return a /= b;
+    }
+
+    friend Complex_t operator/(Complex_t c, T divisor) {
+        return c /= divisor;
+    }
+
+    friend Complex_t operator/(T dividend, const Complex_t& c) {
+        return Complex_t(dividend, 0) / c;
+    }
+
+    friend bool operator==(const Complex_t& a, const Complex_t& b) {
+        return a.m_r == b.m_r && a.m_i == b.m_i;
+    }
+
+    friend bool operator<(const Complex_t& a, const Complex_t& b) {
+        return a.norm_sqr() < b.norm_sqr();
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const Complex_t<T>& c) {
+        return os << "(" << c.real() << ", " << c.imaginary() << ")";
+    }
+
+private:
+    T m_r{}, m_i{};
+};
+
+using Complex = Complex_t<>;

--- a/code/modules/Makefile
+++ b/code/modules/Makefile
@@ -1,0 +1,14 @@
+all: modules
+solution: modules.sol
+
+clean:
+	rm -rf *.o modules gcm.cache
+
+main.o: main.cpp Complex.hpp
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ -c $<
+
+modules : main.o
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ $^
+
+modules.sol:
+	$(MAKE) -C solution modules

--- a/code/modules/README.md
+++ b/code/modules/README.md
@@ -1,0 +1,7 @@
+
+## Instructions
+
+* convert the `Complex.hpp` header into a module named 'math'
+  * you will need to rename `Complex.hpp` into `Complex.cpp`, since it is a translation unit now
+  * you will need to edit the Makefile and add a new target to compile `Complex.cpp`
+* import the module `math` from `main.cpp`

--- a/code/modules/main.cpp
+++ b/code/modules/main.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <numeric>
+#include <random>
+#include "Complex.hpp"
+
+// The code below here should not need to change !!
+
+template<typename T>
+void compute(int len, T initial, T step) {
+    // allocate vectors
+    std::vector<T> v(len+1), diffs(len+1);
+
+    // fill and randomize v
+    std::generate(v.begin(), v.end(), [value = initial, step]() mutable {
+        const T cur = value;
+        value += step;
+        return cur;
+    });
+    std::shuffle(v.begin(), v.end(), std::default_random_engine{});
+
+    // compute differences
+    std::adjacent_difference(v.begin(), v.end(), diffs.begin());
+
+    // compute standard deviation of it
+    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
+    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
+                                [](const T& s, const T& a) { return s + a * a; });
+    const T mean = sum/len;
+    const T variance = sumsq/len - mean*mean;
+
+    std::cout << "Range = [" << initial << ", " << step*len << "]\n"
+              << "Mean = " << mean << '\n'
+              << "Variance = " << variance << '\n';
+}
+
+int main() {
+    compute(1000, 0.0, 7.0);
+    compute(1000, Complex(0,0), Complex(1,2));
+}

--- a/code/modules/solution/Complex.cpp
+++ b/code/modules/solution/Complex.cpp
@@ -1,0 +1,115 @@
+module;
+
+#include <ostream>
+#include <cmath>
+
+export module math;
+
+// You may export Complex_t as well, but for the exercise only the alias Complex at the bottom is neccessary
+template <typename T=float>
+class Complex_t {
+public:
+    Complex_t() = default;
+    Complex_t(T r, T i) : m_r(r), m_i(i) {}
+
+    T real() const { return m_r; }
+    T imaginary() const { return m_i; }
+
+    T norm_sqr() const {
+        return m_r * m_r + m_i * m_i;
+    }
+
+    T norm() const {
+        return std::sqrt(norm_sqr());
+    }
+
+    Complex_t& operator+=(const Complex_t& other) {
+        m_r += other.m_r;
+        m_i += other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator-=(const Complex_t& other) {
+        m_r -= other.m_r;
+        m_i -= other.m_i;
+        return *this;
+    }
+
+    Complex_t& operator*=(const Complex_t& other) {
+        const auto r = m_r * other.m_r - m_i * other.m_i;
+        const auto i = m_r * other.m_i + m_i * other.m_r;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator*=(T factor) {
+        m_r *= factor;
+        m_i *= factor;
+        return *this;
+    }
+
+    Complex_t& operator/=(const Complex_t& other) {
+        const T ns = other.norm_sqr();
+        const auto r = (m_r * other.m_r + m_i * other.m_i) / ns;
+        const auto i = (m_i * other.m_r - m_r * other.m_i) / ns;
+        m_r = r;
+        m_i = i;
+        return *this;
+    }
+
+    Complex_t& operator/=(T divisor) {
+        m_r /= divisor;
+        m_i /= divisor;
+        return *this;
+    }
+
+    friend Complex_t operator+(Complex_t a, const Complex_t& b) {
+        return a += b;
+    }
+
+    friend Complex_t operator-(Complex_t a, const Complex_t& b) {
+        return a -= b;
+    }
+
+    friend Complex_t operator*(Complex_t a, const Complex_t& b) {
+        return a *= b;
+    }
+
+    friend Complex_t operator*(Complex_t c, T factor) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator*(T factor, Complex_t c) {
+        return c *= factor;
+    }
+
+    friend Complex_t operator/(Complex_t a, Complex_t b) {
+        return a /= b;
+    }
+
+    friend Complex_t operator/(Complex_t c, T divisor) {
+        return c /= divisor;
+    }
+
+    friend Complex_t operator/(T dividend, const Complex_t& c) {
+        return Complex_t(dividend, 0) / c;
+    }
+
+    friend bool operator==(const Complex_t& a, const Complex_t& b) {
+        return a.m_r == b.m_r && a.m_i == b.m_i;
+    }
+
+    friend bool operator<(const Complex_t& a, const Complex_t& b) {
+        return a.norm_sqr() < b.norm_sqr();
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const Complex_t<T>& c) {
+        return os << "(" << c.real() << ", " << c.imaginary() << ")";
+    }
+
+private:
+    T m_r{}, m_i{};
+};
+
+export using Complex = Complex_t<>;

--- a/code/modules/solution/Makefile
+++ b/code/modules/solution/Makefile
@@ -1,0 +1,13 @@
+all: modules
+
+clean:
+	rm -rf *.o modules gcm.cache
+
+Complex.o: Complex.cpp
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ -c $<
+
+main.o: main.cpp Complex.o
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ -c $<
+
+modules: main.o Complex.o
+	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ $^

--- a/code/modules/solution/main.cpp
+++ b/code/modules/solution/main.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <numeric>
+#include <random>
+
+import math;
+
+// The code below here should not need to change !!
+
+template<typename T>
+void compute(int len, T initial, T step) {
+    // allocate vectors
+    std::vector<T> v(len+1), diffs(len+1);
+
+    // fill and randomize v
+    std::generate(v.begin(), v.end(), [value = initial, step]() mutable {
+        const T cur = value;
+        value += step;
+        return cur;
+    });
+    std::shuffle(v.begin(), v.end(), std::default_random_engine{});
+
+    // compute differences
+    std::adjacent_difference(v.begin(), v.end(), diffs.begin());
+
+    // compute standard deviation of it
+    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
+    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
+                                [](const T& s, const T& a) { return s + a * a; });
+    const T mean = sum/len;
+    const T variance = sumsq/len - mean*mean;
+
+    std::cout << "Range = [" << initial << ", " << step*len << "]\n"
+              << "Mean = " << mean << '\n'
+              << "Variance = " << variance << '\n';
+}
+
+int main() {
+    compute(1000, 0.0, 7.0);
+    compute(1000, Complex(0,0), Complex(1,2));
+}


### PR DESCRIPTION
This PR adds exercises for header units and modules. Since there is no cmake support for both features yet, I could only add Makefiles for g++.

- [x] Merge #200 first
- [x] Merge #222 first