### PR TITLE
Hidden friends

### DIFF
--- a/talk/objectorientation/adl.tex
+++ b/talk/objectorientation/adl.tex
@@ -144,3 +144,27 @@
     \end{columns}
   \end{block}
 \end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[98]{ADL and Hidden Friends}
+  \begin{block}{Hidden friend declarations participate in ADL}
+    \begin{itemize}
+      \item Friend functions defined in class scope are ``hidden friends''
+      \item They are \emph{not} member functions (no access to \mintinline{cpp}{this})
+      \item They participate in ADL, e.g.\ \mintinline{cpp}{std::cout << complex}
+    \end{itemize}
+  \end{block}
+  \begin{exampleblock}{\texttt{operator<<} as hidden friend}
+    \begin{cppcode*}{gobble=2}
+      class Complex {
+        float m_real, m_imag; public: Complex(float, float);
+        friend
+        std::ostream & operator<<(std::ostream & os,
+                                  Complex const & c) {
+          return os << c.m_real << " + " << c.m_imag << "i";
+        }
+      };
+      std::cout << Complex{2.f, 3.f}; // Prints 2 + 3i
+    \end{cppcode*}
+  \end{exampleblock}
+\end{frame}

--- a/talk/objectorientation/operators.tex
+++ b/talk/objectorientation/operators.tex
@@ -87,6 +87,32 @@
 \end{frame}
 
 \begin{frame}[fragile]
+  \frametitlecpp[98]{Friend declarations}
+  \begin{block}{Concept}
+    \begin{itemize}
+      \item Functions/classes can be declared \mintinline{cpp}{friend} within a class scope
+      \item They gain access to all private/protected members
+      \item Useful for operators such as \mintinline{cpp}{a + b}
+      \item Don't abuse friends to go around a wrongly designed interface
+      \item Avoid unexpected modifications of class state in a friend
+    \end{itemize}
+  \end{block}
+  \begin{block}{\texttt{operator+} as a friend}
+    \small
+    \begin{cppcode*}{gobble=2}
+      class Complex {
+        float m_real, m_imag;
+        friend
+        Complex operator+(Complex const & a, Complex const & b);
+      };
+      Complex operator+(Complex const & a, Complex const & b) {
+        return Complex{ a.m_real+b.m_real, a.m_imag+b.m_imag };
+      }
+    \end{cppcode*}
+  \end{block}
+\end{frame}
+
+\begin{frame}[fragile]
   \frametitlecpp[98]{Operators}
   \begin{alertblock}{Exercise}
     Write a simple class representing a fraction and pass all tests


### PR DESCRIPTION
Fix #203 

See also #200 

We are using friends and also hidden friends (+ADL), but it's not explained. I thought we could benefit from one slide on friends related to operators and one for hidden friends as part of ADL.

### PS
The first shows up in the essentials, and both show up in the full course.