### PR TITLE
Reduce stale-bot noise on issues and pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,7 +9,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 365
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -28,10 +28,10 @@ exemptLabels:
 exemptProjects: false
 
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: false
+exemptMilestones: true
 
 # Set to true to ignore issues with an assignee (defaults to false)
-exemptAssignees: false
+exemptAssignees: true
 
 # Label to use when marking as stale
 staleLabel: stale


### PR DESCRIPTION
The stale bot creates a lot of unnecessary noise. Therefore, increase the timeout to one year,
and exempt everything that has an assignee or a milestone from getting touched by the bot.
