### PR TITLE
Create an index of good practices

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -201,4 +201,11 @@
   \end{center}
 \end{frame}
 
+\section{Index}
+
+\begin{frame}
+  \frametitle{Index of Good Practices}
+  \listofgoodpractices
+\end{frame}
+
 \end{document}

--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -201,7 +201,7 @@
   \end{center}
 \end{frame}
 
-\section{Index}
+\section*{Index}
 
 \begin{frame}
   \frametitle{Index of Good Practices}

--- a/talk/Makefile
+++ b/talk/Makefile
@@ -13,7 +13,7 @@ endif
 	pdflatex -shell-escape C++Course.tex
 
 clean:
-	rm -rf *.aux */*.aux *.log *.nav *.out *.pyg *.snm *.vrb *.toc _minted-C++Course
+	rm -rf *.aux */*.aux *.log *.nav *.out *.pyg *.snm *.vrb *.toc C++Course.l* _minted-C++Course
 
 clobber: clean
 	rm -f C++Course.pdf

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -87,13 +87,42 @@
 \newcommand{\deprecated}{\textcolor{red}{\bf Deprecated}}
 \newcommand{\removed}{\textcolor{red}{\bf Removed}}
 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% boxes with good practices                     %
+% Use \begin{goodpractice}{Title} to create one %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\makeatletter
+\newcommand\listofgoodpractices{%
+  \small
+  \begin{multicols}{2}
+    \begin{enumerate}
+      \@starttoc{lgp}%
+    \end{enumerate}
+  \end{multicols}
+}
+
+\newcounter{gp@counter}
+\def\gp@lasttitle{None}
+
 \newenvironment{goodpractice}[1]
 {%
+  % Generate an entry in the index of good practices. In case of slide overlays, we only generate
+  % an entry for the first slide of the overlay set by saving the last title of the
+  % good practice box.
+  \ifthenelse{\equal{\gp@lasttitle}{#1}}{}{%
+    \hypertarget<\insertslidenumber>{goodpractice.\thegp@counter}{}
+    \addtocontents{lgp}{\protect\item \protect\hyperlink{goodpractice.\thegp@counter}{#1\protect\hfill\insertpagenumber}}
+    \stepcounter{gp@counter}
+    \gdef\gp@lasttitle{#1}
+  }
+  % The box that shows up on the slide
   \begin{beamerboxesrounded}[upper=goodpractice head,lower=goodpractice body,shadow=true]{Good practice: #1}
 }%
 {%
   \end{beamerboxesrounded}
 }
+\makeatother
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % frametitle with C++ version %


### PR DESCRIPTION
Augment the goodpractice environment with automatic entries in the list
of good practices (C++Course.lgp).

The index shows up at the end of the course.

<img width="654" alt="image" src="https://user-images.githubusercontent.com/16205615/191700578-30f252ae-eb3c-4c3d-9045-5e08a81f1655.png">

The same technique could be used to generate an index of all exercises (#267).

Regarding @sponce 's comment in #245:
> For good practices, it should not be so difficult. Just follow the example here:
> https://tex.stackexchange.com/questions/564098/how-to-add-include-the-title-of-custom-new-list-of-on-the-toc

> You basically create a new kind of list, here listing the good practices (maybe call it \listgoodpractice and associate a new command \goodpractice which adds to the list and another one \listofgoodpractices which displays the lit, using the \tocfile command form tocloft package.
Then you only have to call \goodpractice in the definition of your goodpractice block

tocloft doesn't work with beamer. But I guess the stuff I'm doing with `\addtocontents` is simple enough for it not to break in the future.