### PR TITLE
Add a slide on index_sequence with lambda

### DIFF
--- a/talk/expert/variadictemplate.tex
+++ b/talk/expert/variadictemplate.tex
@@ -139,7 +139,7 @@
 
 \begin{frame}[fragile]
   \frametitlecpp[14]{\texttt{std::integer\_sequence}}
-  \begin{exampleblock}{Example - make\_from\_tuple}
+  \begin{exampleblock}{Example - make\_from\_tuple with helper}
     \begin{cppcode*}{}
       template<typename T,
         typename... Args, std::size_t... Is>
@@ -151,6 +151,25 @@
       T make_from_tuple(std::tuple<Args...> args) {
          return helper<T>(args,
            std::make_index_sequence<sizeof...(Args)>{});
+      }
+
+      struct S { S(int, float, bool) { ... } };
+      std::tuple t{42, 3.14, false};
+      S s = make_from_tuple<S>(t);
+    \end{cppcode*}
+  \end{exampleblock}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[20]{\texttt{std::integer\_sequence}}
+  \begin{exampleblock}{Example - make\_from\_tuple with lambda}
+    \begin{cppcode*}{}
+      template<typename T, typename... Args>
+      T make_from_tuple(std::tuple<Args...> args) {
+         return [&]<std::size_t... Is>(
+             std::index_sequence<Is...>){
+           return T(std::get<Is>(args)...);
+         }(std::make_index_sequence<sizeof...(Args)>{});
       }
 
       struct S { S(int, float, bool) { ... } };


### PR DESCRIPTION
We should also show how to use `std::index_sequence` with a lambda, since this use should become more comment as C++20 becomes available.