### PR TITLE
Try macos-12 for CI

### DIFF
--- a/.github/workflows/build-exercises.yml
+++ b/.github/workflows/build-exercises.yml
@@ -49,7 +49,8 @@ jobs:
             GENERATOR: -G "Unix Makefiles"
             env:
               CXX: g++-11
-          - OS: "macos-latest"
+          # We temporarily need to hardcode macos-12, because "-latest" resolves to 11
+          - OS: "macos-12"
             GENERATOR: -G "Xcode"
           - OS: "windows-latest"
             GENERATOR:


### PR DESCRIPTION
To allow compiling c++20 and concepts, try out macos12.

Attempt to fix CI for #261.
