### PR TITLE
Add instructions for module and header units exercise to cheatsheet

### DIFF
--- a/code/ExercisesCheatSheet.md
+++ b/code/ExercisesCheatSheet.md
@@ -176,12 +176,37 @@ To be filled
 
 ### Modules (directory: `modules`)
 
-To be filled
+For this exercise you will convert a header file into a module.
+Students should understand that a module is something different from a header.
+In fact, since a module needs to be compiled, it needs to be its own translation unit.
+That's why we should also rename `Complex.h` to `Complex.cpp`
+(There is a discussion about having different file suffixes for module files in the C++ community, but it has not settled yet).
+Also, we need to have a separate rule in the `Makefile` because we now need to build the module,
+whereas a header was just included and built with the source file including it.
+
+You can ask the students to look into the compiler output files and see that there is also an object file created for `Complex.cpp`.
+Furthermore, GCC creates the compiled module interface as well, which you can find in `gcm.cache/`.
+Make sure students understand the different build process and the artifacts involved.
+
+Furthermore, `export` is required to make entities visible outside the module.
+You can let students play with exporting/not-exporting `Complex`.
+Also point out, that even though `Complex_t<T>` is not exported, `main.cpp` can still use it via the type alias `Complex`.
+But in `main.cpp` we cannot use `Complex_t<T>` directly if it is not exported.
+That is the difference between visibility and reachabilty.
+
+Avoid getting stuck in `Makefile` specifics, help the students with the syntax early.
+Also remind students that this is all experimental and that better build system support (e.g. in cmake) is on its way.
 
 ### Header units (directory: `header_units`)
 
-To be filled
+For this exercise you will convert `#include`s to `import`s
+The key takeaway is that header units are easy to migrate to within the C++ source.
 
+Since header units need to be prebuilt, extra build steps are necessary.
+In practice, this should speed up builds, which this small example cannot demonstrate.
+
+Avoid getting stuck in `Makefile` specifics, help the students with the syntax early.
+Also remind students that this is all experimental and that better build system support (e.g. in cmake) is on its way.
 
 Tools Exercises
 ---------------

--- a/code/ExercisesCheatSheet.md
+++ b/code/ExercisesCheatSheet.md
@@ -154,14 +154,19 @@ Solutions:
 
 1. Add a default constructor
 2. Add an `explicit` to the tuple constructor
-3. head(tuple&) should just return the member m_head
-4. get<I>(tuple&) should be implemented recursively. You can use SFINAE (like on the slides), but prefer `if constexpr`.
-5. Specialize `std::tuple_size`. The value of the trait is sizeof...(Ts) of the template parameter pack in tuple<Ts...>
-6. Specialize `std::tuple_element`. You can implement this recursively with Head/Tail... template parameters.
-   But since get() already does something like that, it is the easiest to just decltype(get<I>(...))
-7. tuple_cat(tuple, tuple): Delegate to a helper tuple_cat(tuple, tuple, index_seq, index_seq) then then just construct a result tuple{get<Is1>(t1)..., get<Is2>(t2)...}
-8. sum(tuple): you need a helper again with a single index sequence, but make it a local lambda this time. Inside the lambda, fold over get<Is>(t)
-9. operator<<: again, needs a helper for the index sequence.
+3. `head(tuple&)` should just return the member `m_head`
+4. `get<I>(tuple&)` should be implemented recursively.
+   You can use SFINAE (like on the slides), but prefer `if constexpr`.
+5. Specialize `std::tuple_size`.
+   The value of the trait is `sizeof...(Ts)` of the template parameter pack in `tuple<Ts...>`
+6. Specialize `std::tuple_element`.
+   You can implement this recursively with Head/Tail... template parameters.
+   But since `get()` already does something like that, it is the easiest to just `decltype(get<I>(...))`
+7. `tuple_cat(tuple, tuple)`: Delegate to a `helper tuple_cat(tuple, tuple, index_seq, index_seq)`.
+   Then just construct a result `tuple{get<Is1>(t1)..., get<Is2>(t2)...}`.
+8. `sum(tuple)`: you need a helper again with a single index sequence, but make it a local lambda this time.
+   Inside the lambda, fold over `get<Is>(t)`.
+9. `operator<<`: again, needs a helper for the index sequence.
    To intersperse the ", " between elements, you need more logic so a fold over << won't work. Use a fold over comma.
    Finally, to omit the last ", ", just use a conditional expression comparing the expanded index pack against the index pack size
 

--- a/code/modules/Makefile
+++ b/code/modules/Makefile
@@ -7,7 +7,7 @@ clean:
 main.o: main.cpp Complex.hpp
 	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ -c $<
 
-modules : main.o
+modules: main.o
 	${CXX} -std=c++20 -fmodules-ts -g -O0 -Wall -Wextra -o $@ $^
 
 modules.sol:

--- a/code/modules/solution/Complex.cpp
+++ b/code/modules/solution/Complex.cpp
@@ -1,9 +1,9 @@
-module;
+module; // start the module global partition
 
 #include <ostream>
 #include <cmath>
 
-export module math;
+export module math; // declare that we intend to export a new module named 'math'
 
 // You may export Complex_t as well, but for the exercise only the alias Complex at the bottom is neccessary
 template <typename T=float>
@@ -112,4 +112,4 @@ private:
     T m_r{}, m_i{};
 };
 
-export using Complex = Complex_t<>;
+export using Complex = Complex_t<>; // export the alias Complex


### PR DESCRIPTION
I start to wonder what the goal of the cheatsheet is. IMO it should neither repeat the exercise instructions from the exercise README.md nor the instructions from the slides. What else is left? :)