### PR TITLE
Improvements to concurrency chapter

### DIFF
--- a/code/condition_variable/condition_variable.cpp
+++ b/code/condition_variable/condition_variable.cpp
@@ -13,13 +13,12 @@
  */
 using namespace std::chrono_literals; // We can write 1s
 
-std::mutex cout_mutex; // We need this to synchronise printing
-
 // Print contents of the stream to cout in a thread-safe manner.
 // This class consumes stream inputs, buffers them, and writes them
 // out when destructed respecting the cout_mutex.
 class SafeCout {
   std::stringstream stream;
+  inline static std::mutex cout_mutex; // We need this to synchronise printing
 
 public:
   ~SafeCout() {
@@ -33,7 +32,6 @@ public:
     return *this;
   }
 };
-
 
 // A mock data object
 struct Data {
@@ -108,7 +106,7 @@ int main() {
 
     auto result = process(threadIdx, data);
 
-    SafeCout{} << '[' << threadIdx << "] Done " << (result ? "OK" : "with failure!") << '\n';
+    SafeCout{} << '[' << threadIdx << "] Data processing completed " << (result ? "OK" : "with failure!") << '\n';
   };
 
   std::vector<std::thread> consumers;

--- a/code/condition_variable/solution/condition_variable.sol.cpp
+++ b/code/condition_variable/solution/condition_variable.sol.cpp
@@ -13,13 +13,12 @@
  */
 using namespace std::chrono_literals; // We can write 1s
 
-std::mutex cout_mutex; // We need this to synchronise printing
-
 // Print contents of the stream to cout in a thread-safe manner.
 // This class consumes stream inputs, buffers them, and writes them
 // out when destructed respecting the cout_mutex.
 class SafeCout {
   std::stringstream stream;
+  inline static std::mutex cout_mutex; // We need this to synchronise printing
 
 public:
   ~SafeCout() {
@@ -33,7 +32,6 @@ public:
     return *this;
   }
 };
-
 
 // A mock data object
 struct Data {
@@ -108,7 +106,7 @@ int main() {
     }
     auto result = process(threadIdx, data);
 
-    SafeCout{} << '[' << threadIdx << "] Done " << (result ? "OK" : "with failure!") << '\n';
+    SafeCout{} << '[' << threadIdx << "] Data processing completed " << (result ? "OK" : "with failure!") << '\n';
   };
 
   std::vector<std::thread> consumers;

--- a/talk/concurrency/atomic.tex
+++ b/talk/concurrency/atomic.tex
@@ -22,15 +22,15 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \begin{alertblock}{Expressions using an atomic type are \textit{not} atomic!}
-    \begin{itemize}
-      \item Atomic load; value+2; atomic store
-    \end{itemize}
+  \begin{alertblock}{Warning: Expressions using an atomic type are \textit{not} atomic!}
     \begin{cppcode*}{}
       std::atomic<int> a{0};
       std::thread t1([&]{ a = a + 2; });
       std::thread t2([&]{ a = a + 2; });
     \end{cppcode*}
+    \begin{itemize}
+      \item Atomic load; value+2; atomic store
+    \end{itemize}
   \end{alertblock}
   \begin{block}{Sequence diagram}
     \begin{tikzpicture}
@@ -57,7 +57,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \begin{block}{Use atomic member functions}
+  \begin{block}{Solution: Use atomic member functions}
     \begin{itemize}
       \item The member functions of \mintinline{cpp}{std::atomic} are thread safe
       \item \mintinline{cpp}{fetch_add} and \mintinline{cpp}{operator+=}: atomic \{ load; add; store \}

--- a/talk/concurrency/condition.tex
+++ b/talk/concurrency/condition.tex
@@ -2,9 +2,13 @@
 
 \begin{frame}[fragile]
   \frametitlecpp[11]{Condition variables}
-  \begin{block}{Communicating thread dependencies}
+  \begin{block}{Communicating between threads}
     \begin{itemize}
-      \item \mintinline{cpp}{std::condition_variable} from \mintinline{cpp}{<condition_variable>} header
+      \item Take the case where threads are waiting for other thread(s)
+      \item \mintinline{cpp}{std::condition_variable}
+      \begin{itemize}
+        \item from \mintinline{cpp}{<condition_variable>} header
+      \end{itemize}
       \item Allows for a thread to sleep (= conserve CPU time) until a given condition is satisfied
     \end{itemize}
   \end{block}
@@ -23,12 +27,14 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[17]{Using condition variables}
-  \begin{block}{Producer side}
+  \frametitlecpp[17]{Using condition variables: notify}
+  \begin{block}{Producer side: providing data to waiting threads}
     \begin{itemize}
-      \item Imagine multiple threads sharing data. Protect it with a mutex
-      \item Use a condition variable to notify consumers
-      \item Optimization: Don't hold lock while notifying (would block the waking threads)
+      \item Protect data with a mutex, and use condition variable to notify consumers
+      \item Optimal use: don't hold lock while notifying
+      \begin{itemize}
+        \item waiting threads would be blocked
+      \end{itemize}
     \end{itemize}
   \end{block}
   \begin{exampleblock}{}
@@ -48,43 +54,51 @@
 \end{frame}
 
 \begin{frame}[fragile]
+  \frametitlecpp[11]{Using condition variables: wait}
+  \vspace{-1.2\baselineskip}
   \begin{overprint}
   \onslide<1>
-  \begin{block}{Consumer side I: Going into wait}
+  \begin{block}{Mechanics of wait}
     \begin{itemize}
-      \item Start many threads which have to wait for shared data
-      \item Provide a lock to be managed by \mintinline{cpp}{wait}
-      \item \mintinline{cpp}{wait} will only lock while necessary; unlocked while sleeping
-      \item Threads might wake up, but \mintinline{cpp}{wait} returns only when condition satisfied
+      \item Many threads are waiting for shared data
+      \item Pass a \mintinline{cpp}{unique_lock} and a predicate for wakeup to \mintinline{cpp}{wait()}
+      \item \mintinline{cpp}{wait()} sends threads to sleep while predicate is \mintinline{cpp}{false}
+      \item \mintinline{cpp}{wait()} will only lock when necessary; unlocked while sleeping
+      \item Threads might wake up spuriously, but \mintinline{cpp}{wait()} returns only when lock available \emph{and} predicate \mintinline{cpp}{true}
     \end{itemize}
   \end{block}
   \onslide<2->
-  \begin{block}{Consumer side II: Waking up}
+  \begin{block}{Waiting / waking up}
     \begin{itemize}
       \item \mintinline{cpp}{notify_all()} is called, threads wake up
-      \item Threads try to acquire mutex, evaluate condition
-      \item One thread succeeds to acquire mutex, exits from \mintinline{cpp}{wait}
-      \item \alt<2>{ {\color{red} Problem}: Other threads still blocked!}{ {\color{green!80!black} Solution:} Put locking and waiting in a scope}
+      \item Threads try to lock mutex, and evaluate predicate
+      \item One thread succeeds to acquire mutex, starts data processing
+      \item {\color{red} Problem}: Thread holds mutex now, other threads are blocked!
     \end{itemize}
   \end{block}
   \end{overprint}
 
-  \begin{exampleblock}{}
-    \begin{overprint}
-    \onslide<1-2>
-    \begin{cppcode*}{gobble=2,highlightlines=4}
+  \begin{alertblock}{Na\"ive waiting}
+    \begin{cppcode*}{gobble=2,highlightlines=3}
       auto processData = [&](){
-
         std::unique_lock<std::mutex> lock{mutex};
         cond.wait(lock, [&](){ return data.isReady(); });
-
         process(data);
       };
-      std::thread t1{processData}, t2{processData}, ...;
-      for (auto t : {&producer, &t1, &t2, ...}) t->join();
     \end{cppcode*}
+  \end{alertblock}
+\end{frame}
 
-    \onslide<3>
+\begin{frame}[fragile]
+  \frametitlecpp[11]{Using condition variables: correct wait}
+  \begin{block}{Waiting / waking up}
+    \begin{itemize}
+      \item {\color{green!50!black} Solution:} Put locking and waiting in a scope
+      \item Threads will one-by-one wake up, acquire lock, evaluate predicate, release lock
+    \end{itemize}
+  \end{block}
+
+  \begin{exampleblock}{Correct waiting}
     \begin{cppcode*}{gobble=2}
       auto processData = [&](){
         {
@@ -96,7 +110,6 @@
       std::thread t1{processData}, t2{processData}, ...;
       for (auto t : {&producer, &t1, &t2, ...}) t->join();
     \end{cppcode*}
-    \end{overprint}
   \end{exampleblock}
 \end{frame}
 

--- a/talk/concurrency/mutexes.tex
+++ b/talk/concurrency/mutexes.tex
@@ -10,10 +10,10 @@
         for (int i=0; i < 100; i++) inc();
       };
       int main() {
-        std::thread t1(inc100);
-        std::thread t2(inc100);
+        std::thread t1{inc100};
+        std::thread t2{inc100};
         for (auto t: {&t1,&t2}) t->join();
-        std::cout << a << std::endl;
+        std::cout << a << "\n";
       }
     \end{cppcode*}
   \end{exampleblock}

--- a/talk/concurrency/mutexes.tex
+++ b/talk/concurrency/mutexes.tex
@@ -18,7 +18,7 @@
     \end{cppcode*}
   \end{exampleblock}
   \pause
-  \begin{block}{What do you expect ? Try it in code/race}
+  \begin{block}{What do you expect? (Exercise code/race)}
     \pause
     Anything between 100 and 200 !!!
   \end{block}
@@ -33,7 +33,7 @@
   \end{exampleblock}
   \begin{block}{Practically}
     \begin{itemize}
-    \item an operation that won't run concurrently to another one
+    \item an operation that won't be interrupted by other concurrent operations
     \item an operation that will have a stable environment during execution
     \end{itemize}
   \end{block}
@@ -122,11 +122,12 @@
   \begin{exampleblock}{}
     \begin{cppcode*}{gobble=2}
       void function(...) {
-        // ...
+        // uncritical work ...
         {
           std::scoped_lock myLocks{mutex1, mutex2, ...};
           // critical section
         }
+        // uncritical work ...
       }
     \end{cppcode*}
   \end{exampleblock}
@@ -146,13 +147,13 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[11]{Dead lock}
-  \begin{exampleblock}{Scenario}
+  \frametitlecpp[11]{Dead locks}
+  \begin{block}{Scenario}
     \begin{itemize}
     \item 2 mutexes, 2 threads
     \item locking order different in the 2 threads
     \end{itemize}
-  \end{exampleblock}
+  \end{block}
   \pause
   \begin{block}{Sequence diagram}
     \begin{tikzpicture}
@@ -184,10 +185,10 @@
       \begin{itemize}
       \item Or add master lock protecting the locking phase
       \end{itemize}
-    \item Respect a strict order in the locking across all threads
+    \item Respect a strict locking order across all threads
     \item Do not use locks
       \begin{itemize}
-      \item Use other techniques, e.g. lock-free queues
+      \item Use other techniques, e.g.\ lock-free queues
       \end{itemize}
     \end{itemize}
   \end{block}
@@ -199,7 +200,7 @@
     \begin{itemize}
       \item Normal \mintinline{cpp}{std::mutex} objects cannot be shared
       \item \mintinline{cpp}{std::shared_mutex} to the rescue, but can be slower
-      \item \emph{Either} exclusive \emph{or} shared locking; never both
+      \item It locks \emph{either} in exclusive \emph{or} in shared mode; never both
     \end{itemize}
   \end{block}
   \begin{exampleblock}{}

--- a/talk/concurrency/threadsasync.tex
+++ b/talk/concurrency/threadsasync.tex
@@ -16,8 +16,8 @@
       void foo() {...}
       void bar() {...}
       int main() {
-        std::thread t1(foo);
-        std::thread t2(bar);
+        std::thread t1{foo};
+        std::thread t2{bar};
         for (auto t: {&t1,&t2}) t->join();
       }
     \end{cppcode*}
@@ -29,7 +29,7 @@
   \begin{exampleblock}{Can take a function and its arguments}
     \begin{cppcode*}{}
       void function(int j, double j) {...};
-      std::thread t1(function, 1, 2.0);
+      std::thread t1{function, 1, 2.0};
     \end{cppcode*}
   \end{exampleblock}
   \pause
@@ -40,10 +40,10 @@
         int operator() (int j) const { return i+j; };
         int m_i;
       };
-      std::thread t2(AdderFunctor(2), 5);
+      std::thread t2{AdderFunctor{2}, 5};
       int a;
-      std::thread t3([](int i) { return i+2; }, a);
-      std::thread t4([a]       { return a+2; });
+      std::thread t3{[](int i) { return i+2; }, a};
+      std::thread t4{[a]       { return a+2; }};
     \end{cppcode*}
   \end{exampleblock}
 \end{frame}
@@ -68,7 +68,7 @@
     \begin{cppcode*}{}
       int f() {...}
       std::future<int> res = std::async(f);
-      std::cout << res->get();
+      std::cout << res.get() << "\n";
     \end{cppcode*}
   \end{exampleblock}
 \end{frame}
@@ -116,7 +116,7 @@
   \begin{exampleblock}{Usage}
     \begin{cppcode*}{}
       int f() { return 42; }
-      std::packaged_task<int()> task(f);
+      std::packaged_task<int()> task{f};
       auto future = task.get_future();
       task();
       std::cout << future.get() << std::endl;

--- a/talk/concurrency/threadsasync.tex
+++ b/talk/concurrency/threadsasync.tex
@@ -4,7 +4,7 @@
   \frametitlecpp[11]{Basic concurrency}
   \begin{block}{Threading}
     \begin{itemize}
-    \item new object \mintinline{cpp}{std::thread} in \mintinline{cpp}{<thread>} header
+    \item \cpp11 added \mintinline{cpp}{std::thread} in \mintinline{cpp}{<thread>} header
     \item takes a function as argument of its constructor
     \item must be detached or joined before the main thread terminates
     \item \cpp20: \mintinline{cpp}{std::jthread} automatically joins at destruction
@@ -37,7 +37,7 @@
     \begin{cppcode*}{}
       struct AdderFunctor {
         AdderFunctor(int i): m_i(i) {}
-        int operator() (int j) const { return i+j; };
+        int operator() (int j) const { return m_i+j; }
         int m_i;
       };
       std::thread t2{AdderFunctor{2}, 5};
@@ -86,7 +86,7 @@
       \begin{itemize}
       \item execution starts when \mintinline{cpp}{get()} is called on the returned future
       \end{itemize}
-    \item default is not specified!
+    \item default is not specified, but tries to use existing concurrency!
     \end{itemize}
   \end{block}
   \pause
@@ -100,7 +100,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[11]{Fine grained control on asynchronous execution}
+  \frametitlecpp[11]{Fine-grained control on asynchronous execution}
   \begin{block}{\texttt{std::packaged\_task} template}
     \begin{itemize}
     \item creates an asynchronous version of any function-like object


### PR DESCRIPTION
Four commits, in order of importance:
- Rework slides on condition_variable.
- Small tweaks in condition_variable exercise.
- Small improvements to concurrency chapter.
- [NFC] Use {} for init and \n for endl in concurrency chapter.
