### PR TITLE
Reword default ctor example

### DIFF
--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -186,8 +186,8 @@
   \end{block}
   \begin{exampleblock}{Practically}
     \begin{cppcode}
-      ClassName() = default;  // provide/force default
-      ClassName() = delete;   // do not provide default
+      ClassName() = default; // provide default if possible
+      ClassName() = delete;  // disable default constructor
     \end{cppcode}
   \end{exampleblock}
 \end{frame}


### PR DESCRIPTION
"force" sounds like `= default` will force the compiler to generate the constructor, which is not the case (the compiler will happily, silently avoid generating a defaulted member function if it would be ill-formed).