### PR TITLE
Nothrow functions don't always handle errors successfully

### DIFF
--- a/talk/morelanguage/exceptions.tex
+++ b/talk/morelanguage/exceptions.tex
@@ -379,7 +379,7 @@
       \item No-throw guarantee
       \begin{itemize}
         \item The function never throws (e.g.\ is marked \mintinline{cpp}{noexcept})
-        \item Errors may occur internally, but are always handled successfully
+        \item Errors are handled internally or lead to termination
       \end{itemize}
     \end{itemize}
   \end{block}


### PR DESCRIPTION
But if they do not, they have to terminate.