### PR TITLE
Improve wording about uninitialized values

### DIFF
--- a/talk/morelanguage/initialization.tex
+++ b/talk/morelanguage/initialization.tex
@@ -98,8 +98,8 @@
     \end{cppcode*}
     \begin{itemize}
       \item If \mintinline{cpp}{T} has a default constructor (including compiler generated), calls it
-      \item Otherwise \mintinline{cpp}{t} is left uninitialized (undefined value)
-      \item If \mintinline{cpp}{T} is an array, default initializes all members
+      \item If \mintinline{cpp}{T} is a fundamental type, \mintinline{cpp}{t} is left uninitialized (undefined value)
+      \item If \mintinline{cpp}{T} is an array, the same rules are applied to each item
     \end{itemize}
   \end{block}
 \end{frame}


### PR DESCRIPTION
- Clarify that only ~~primitive~~ fundamental types can be uninitialized: the previous wording seemed to indicate that any object of a type T that does not have a default constructor can be left uninitialized.
- ~~Remove~~ Reword wrong statement about array initialization