### PR TITLE
Minor fixes to perfect forwarding section

### DIFF
--- a/talk/expert/perfectforwarding.tex
+++ b/talk/expert/perfectforwarding.tex
@@ -57,7 +57,6 @@
   \begin{alertblock}{}
     \begin{itemize}
       \item \mintinline{cpp}{const T&} won't work when passing something non const
-      \item rvalues are not supported in either case
     \end{itemize}
   \end{alertblock}
 \end{frame}

--- a/talk/expert/perfectforwarding.tex
+++ b/talk/expert/perfectforwarding.tex
@@ -72,7 +72,7 @@
       void wrapper(const T& arg) { func(arg); }
 
       template <typename T>
-      void wrapper(T&& arg) { func(arg); }
+      void wrapper(T&& arg) { func(std::move(arg)); }
     \end{cppcode*}
   \end{block}{}
 \end{frame}


### PR DESCRIPTION
- Remove a wrong statement: rvalues would actually be supported if wrapper took a constT&
- Preserve value type in wrapper function