### PR TITLE
Minor improvements to variant exercise

### DIFF
--- a/code/variant/solution/variant.sol1.cpp
+++ b/code/variant/solution/variant.sol1.cpp
@@ -3,15 +3,15 @@
 #include <vector>
 
 struct Electron {
-  void print() const { std::cout << "E" << std::endl; }
+  void print() const { std::cout << "E\n"; }
 };
 
 struct Proton {
-  void print() const { std::cout << "P" << std::endl; }
+  void print() const { std::cout << "P\n"; }
 };
 
 struct Neutron {
-  void print() const { std::cout << "N" << std::endl; }
+  void print() const { std::cout << "N\n"; }
 };
 
 using Particle = std::variant<Electron, Proton, Neutron>;

--- a/code/variant/solution/variant.sol2.cpp
+++ b/code/variant/solution/variant.sol2.cpp
@@ -3,15 +3,15 @@
 #include <vector>
 
 struct Electron {
-  void print() const { std::cout << "E" << std::endl; }
+  void print() const { std::cout << "E\n"; }
 };
 
 struct Proton {
-  void print() const { std::cout << "P" << std::endl; }
+  void print() const { std::cout << "P\n"; }
 };
 
 struct Neutron {
-  void print() const { std::cout << "N" << std::endl; }
+  void print() const { std::cout << "N\n"; }
 };
 
 using Particle = std::variant<Electron, Proton, Neutron>;

--- a/code/variant/variant.cpp
+++ b/code/variant/variant.cpp
@@ -17,15 +17,15 @@ struct Particle {
 };
 
 struct Electron : Particle {
-  void print() const override { std::cout << "E" << std::endl; }
+  void print() const override { std::cout << "E\n"; }
 };
 
 struct Proton : Particle {
-  void print() const override { std::cout << "P" << std::endl; }
+  void print() const override { std::cout << "P\n"; }
 };
 
 struct Neutron : Particle {
-  void print() const override { std::cout << "N" << std::endl; }
+  void print() const override { std::cout << "N\n"; }
 };
 
 int main() {

--- a/code/variant/variant.cpp
+++ b/code/variant/variant.cpp
@@ -16,16 +16,16 @@ struct Particle {
   virtual ~Particle() = default;
 };
 
-struct Electron : public Particle {
-  virtual void print() const { std::cout << "E" << std::endl; }
+struct Electron : Particle {
+  void print() const override { std::cout << "E" << std::endl; }
 };
 
-struct Proton : public Particle {
-  virtual void print() const { std::cout << "P" << std::endl; }
+struct Proton : Particle {
+  void print() const override { std::cout << "P" << std::endl; }
 };
 
-struct Neutron : public Particle {
-  virtual void print() const { std::cout << "N" << std::endl; }
+struct Neutron : Particle {
+  void print() const override { std::cout << "N" << std::endl; }
 };
 
 int main() {


### PR DESCRIPTION
- prefer `final` to `virtual` for overrides
- structs inherit publicly by default.
- avoid std::endl in variant exercise, in order to promote best practices, as per C++ core guidelines:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rio-endl

As an aside, I realize that the purpose of the solution with `get_if` is just to show how `get_if` works, but that code should not pass a code review so I wonder whether it's ok to teach it as a valid solution.