### PR TITLE
Prefer unique_ptr<T[]> to manual memory management in templates ex

### DIFF
--- a/code/templates/CMakeLists.txt
+++ b/code/templates/CMakeLists.txt
@@ -3,6 +3,9 @@
 cmake_minimum_required( VERSION 3.12 )
 project( templates LANGUAGES CXX )
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set up the compilation environment.
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../CompilerSettings.cmake" )
 include( "${CMAKE_CURRENT_SOURCE_DIR}/../SolutionTarget.cmake" )

--- a/code/templates/Makefile
+++ b/code/templates/Makefile
@@ -5,7 +5,7 @@ clean:
 	rm -f *o *so playwithsort *~ playwithsort.sol
 
 playwithsort : playwithsort.cpp OrderedVector.hpp Complex.hpp
-	$(CXX) -std=c++11 -g -O0 -Wall -Wextra -o $@ $<
+	$(CXX) -std=c++17 -g -O0 -Wall -Wextra -o $@ $<
 
 playwithsort.sol : solution/playwithsort.sol.cpp solution/OrderedVector.sol.hpp Complex.hpp
-	$(CXX) -std=c++11 -g -O0 -Wall -Wextra -I. -o $@ $<
+	$(CXX) -std=c++17 -g -O0 -Wall -Wextra -I. -o $@ $<

--- a/code/templates/OrderedVector.hpp
+++ b/code/templates/OrderedVector.hpp
@@ -1,10 +1,10 @@
+#include <memory>
 #include <stdexcept>
 
 template<typename ElementType>
 class OrderedVector {
 public:
     OrderedVector(unsigned int maxLen);
-    ~OrderedVector();
     OrderedVector(const OrderedVector&) = delete;
     OrderedVector& operator=(const OrderedVector&) = delete;
     bool add(ElementType value);
@@ -13,19 +13,12 @@ public:
 private:
     unsigned int m_len;
     unsigned int m_maxLen;
-    ElementType* m_data;
+    std::unique_ptr<ElementType[]> m_data;
 };
 
 template<typename ElementType>
-OrderedVector<ElementType>::~OrderedVector() {
-    delete[] m_data;
-}
-
-template<typename ElementType>
 OrderedVector<ElementType>::OrderedVector(unsigned int maxLen) :
-m_len(0), m_maxLen(maxLen) {
-    m_data = new ElementType[m_maxLen];
-}
+m_len(0), m_maxLen(maxLen), m_data(std::make_unique<ElementType[]>(m_maxLen)) { }
 
 template<typename ElementType>
 bool OrderedVector<ElementType>::add(ElementType value) {

--- a/code/templates/solution/OrderedVector.sol.hpp
+++ b/code/templates/solution/OrderedVector.sol.hpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <stdexcept>
 
 template <typename T>
@@ -9,7 +10,6 @@ template<typename ElementType, typename Compare=less<ElementType> >
 class OrderedVector {
 public:
     OrderedVector(unsigned int maxLen);
-    ~OrderedVector();
     OrderedVector(const OrderedVector&) = delete;
     OrderedVector& operator=(const OrderedVector&) = delete;
     bool add(ElementType value);
@@ -19,19 +19,12 @@ private:
     unsigned int m_len;
     unsigned int m_maxLen;
     Compare m_compare;
-    ElementType* m_data;
+    std::unique_ptr<ElementType[]> m_data;
 };
 
 template<typename ElementType, typename Compare>
-OrderedVector<ElementType,Compare>::~OrderedVector() {
-    delete[] m_data;
-}
-
-template<typename ElementType, typename Compare>
 OrderedVector<ElementType,Compare>::OrderedVector(unsigned int maxLen) :
-m_len(0), m_maxLen(maxLen), m_compare() {
-    m_data = new ElementType[m_maxLen];
-}
+m_len(0), m_maxLen(maxLen), m_compare(), m_data(std::make_unique<ElementType[]>(m_maxLen)) { }
 
 template<typename ElementType, typename Compare>
 bool OrderedVector<ElementType,Compare>::add(ElementType value) {


### PR DESCRIPTION
It makes code "more RAII" and removes the need to implement a dtor.

I'd use `make_unique` instead of `new` but the Makefile explicitly builds with `-std=c++11` so I don't have `make_unique`. I don't know if we can bump it to C++14 instead.

I realize that this patch might be controversial for some, but I feel like an advanced C++ course should show that you basically never need to do manual memory management anymore in 2022.