### PR TITLE
Use more inline definitions in templates exercise

### DIFF
--- a/code/templates/Complex.hpp
+++ b/code/templates/Complex.hpp
@@ -3,72 +3,52 @@
 template <typename T=float>
 class Complex_t {
 public:
-    Complex_t(T r, T i);
-    Complex_t();
+    Complex_t() = default;
 
-    T real() const {return m_r;};
-    T imaginary() const {return m_i;};
+    Complex_t(T r, T i)
+    : m_r(r), m_i(i) {}
 
-    Complex_t operator+(const Complex_t& other) const;
-    Complex_t operator-(const Complex_t& other) const;
-    Complex_t operator*(const Complex_t& other) const;
-    Complex_t operator*(const T factor) const;
-    Complex_t operator/(const T dividend) const;
-    Complex_t& operator+=(const Complex_t& other);
-    bool operator<(const Complex_t& a) const;
+    T real() const { return m_r; }
+
+    T imaginary() const { return m_i; }
+
+    Complex_t operator+(const Complex_t& other) const {
+        return Complex_t(m_r + other.m_r, m_i + other.m_i);
+    }
+
+    Complex_t operator-(const Complex_t& other) const {
+        return Complex_t(m_r - other.m_r, m_i - other.m_i);
+    }
+
+    Complex_t operator*(const Complex_t& other) const {
+        return Complex_t(m_r * other.m_r - m_i * other.m_i,
+            m_r * other.m_i + m_i * other.m_r);
+    }
+
+    Complex_t operator*(const T factor) const {
+        return Complex_t(m_r * factor, m_i * factor);
+    }
+
+    Complex_t operator/(const T dividend) const {
+        return Complex_t(m_r / dividend, m_i / dividend);
+    }
+
+    Complex_t& operator+=(const Complex_t& other) {
+        m_r += other.m_r;
+        m_i += other.m_i;
+        return *this;
+    }
+
+    friend bool operator<(const Complex_t& a, const Complex_t& b) {
+        return (a.m_r * a.m_r + a.m_i * a.m_i) < (b.m_r * b.m_r + b.m_i * b.m_i);
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const Complex_t& c) {
+        return os << "(" << c.real() << ", " << c.imaginary() << ")";
+    }
+
 private:
     T m_r{}, m_i{};
 };
 
-typedef Complex_t<> Complex;
-
-template <typename T>
-Complex_t<T>::Complex_t() {}
-
-template <typename T>
-Complex_t<T>::Complex_t(T r, T i) : m_r(r), m_i(i) {}
-
-template <typename T>
-Complex_t<T> Complex_t<T>::operator+(const Complex_t<T>& other) const {
-    return Complex_t(m_r + other.m_r, m_i + other.m_i);
-}
-
-template <typename T>
-Complex_t<T> Complex_t<T>::operator-(const Complex_t<T>& other) const {
-    return Complex_t(m_r - other.m_r, m_i - other.m_i);
-}
-
-template <typename T>
-Complex_t<T> Complex_t<T>::operator*(const Complex_t<T>& other) const {
-    return Complex_t(m_r*other.m_r - m_i*other.m_i,
-                     m_r*other.m_i + m_i*other.m_r);
-}
-
-template <typename T>
-Complex_t<T> Complex_t<T>::operator*(const T factor) const {
-    return Complex_t(m_r*factor, m_i*factor);
-}
-
-template <typename T>
-Complex_t<T> Complex_t<T>::operator/(const T dividend) const {
-    return Complex_t(m_r/dividend, m_i/dividend);
-}
-
-template <typename T>
-Complex_t<T>& Complex_t<T>::operator+=(const Complex_t<T>& other) {
-    m_r += other.m_r;
-    m_i += other.m_i;
-    return *this;
-}
-
-template <typename T>
-bool Complex_t<T>::operator<(const Complex_t<T>& other) const {
-    return (m_r*m_r+m_i*m_i) < (other.m_r*other.m_r+other.m_i*other.m_i);
-}
-
-template <typename T>
-std::ostream& operator<<(std::ostream& os,
-                         const Complex_t<T>& c) {
-    os << "(" << c.real() << ", " << c.imaginary() << ")";
-    return os;
-}
+using Complex = Complex_t<>;

--- a/code/templates/OrderedVector.hpp
+++ b/code/templates/OrderedVector.hpp
@@ -4,21 +4,30 @@
 template<typename ElementType>
 class OrderedVector {
 public:
-    OrderedVector(unsigned int maxLen);
+    OrderedVector(unsigned int maxLen)
+      : m_maxLen(maxLen), m_data(std::make_unique<ElementType[]>(m_maxLen)) { }
+
     OrderedVector(const OrderedVector&) = delete;
     OrderedVector& operator=(const OrderedVector&) = delete;
+
     bool add(ElementType value);
-    ElementType& at(unsigned int n);
-    ElementType& operator[](unsigned int n);
+
+    ElementType& at(unsigned int n) {
+      if (n >= m_len) {
+        throw std::out_of_range("too big");
+      }
+      return m_data[n];
+    }
+
+    ElementType& operator[](unsigned int n) {
+      return at(n);
+    }
+
 private:
-    unsigned int m_len;
+    unsigned int m_len = 0;
     unsigned int m_maxLen;
     std::unique_ptr<ElementType[]> m_data;
 };
-
-template<typename ElementType>
-OrderedVector<ElementType>::OrderedVector(unsigned int maxLen) :
-m_len(0), m_maxLen(maxLen), m_data(std::make_unique<ElementType[]>(m_maxLen)) { }
 
 template<typename ElementType>
 bool OrderedVector<ElementType>::add(ElementType value) {
@@ -39,17 +48,4 @@ bool OrderedVector<ElementType>::add(ElementType value) {
     m_data[index] = value;
     m_len++;
     return true;
-}
-
-template<typename ElementType>
-ElementType& OrderedVector<ElementType>::at(unsigned int n) {
-    if (n >= m_len) {
-        throw std::out_of_range("too big");
-    }
-    return m_data[n];
-}
-
-template<typename ElementType>
-ElementType& OrderedVector<ElementType>::operator[](unsigned int n) {
-    return at(n);
 }

--- a/code/templates/solution/OrderedVector.sol.hpp
+++ b/code/templates/solution/OrderedVector.sol.hpp
@@ -5,25 +5,34 @@
 template<typename ElementType, typename Compare=std::less<>>
 class OrderedVector {
 public:
-    OrderedVector(unsigned int maxLen);
+    OrderedVector(unsigned int maxLen)
+      : m_maxLen(maxLen), m_data(std::make_unique<ElementType[]>(m_maxLen)) { }
+
     OrderedVector(const OrderedVector&) = delete;
     OrderedVector& operator=(const OrderedVector&) = delete;
+
     bool add(ElementType value);
-    ElementType& at(unsigned int n);
-    ElementType& operator[](unsigned int n);
+
+    ElementType& at(unsigned int n) {
+      if (n >= m_len) {
+        throw std::out_of_range("too big");
+      }
+      return m_data[n];
+    }
+
+    ElementType& operator[](unsigned int n) {
+      return at(n);
+    }
+
 private:
-    unsigned int m_len;
+    unsigned int m_len = 0;
     unsigned int m_maxLen;
     Compare m_compare;
     std::unique_ptr<ElementType[]> m_data;
 };
 
 template<typename ElementType, typename Compare>
-OrderedVector<ElementType,Compare>::OrderedVector(unsigned int maxLen) :
-m_len(0), m_maxLen(maxLen), m_compare(), m_data(std::make_unique<ElementType[]>(m_maxLen)) { }
-
-template<typename ElementType, typename Compare>
-bool OrderedVector<ElementType,Compare>::add(ElementType value) {
+bool OrderedVector<ElementType, Compare>::add(ElementType value) {
     if (m_len >= m_maxLen) {
         return false;
     }
@@ -41,17 +50,4 @@ bool OrderedVector<ElementType,Compare>::add(ElementType value) {
     m_data[index] = value;
     m_len++;
     return true;
-}
-
-template<typename ElementType, typename Compare>
-ElementType& OrderedVector<ElementType,Compare>::at(unsigned int n) {
-    if (n >= m_len) {
-        throw std::out_of_range("too big");
-    }
-    return m_data[n];
-}
-
-template<typename ElementType, typename Compare>
-ElementType& OrderedVector<ElementType,Compare>::operator[](unsigned int n) {
-    return at(n);
 }


### PR DESCRIPTION
This should reduce the amount of code a bit. Students also need to change the template heads in less places when adding the ordering predicate.