### PR TITLE
Remove python3 workflow action.

### DIFF
--- a/.github/workflows/build-exercises.yml
+++ b/.github/workflows/build-exercises.yml
@@ -98,10 +98,6 @@ jobs:
     steps:
     # Use a standard checkout of the code.
     - uses: actions/checkout@v3
-    # Make sure that Python 3 is available to the build.
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
     # Run the CMake configuration.
     - name: CMake Configure
       run: cmake -S ${{ github.workspace }}/code/${{ matrix.EXERCISE.NAME }}


### PR DESCRIPTION
It's unclear why every workflow run would run a python setup step, even if no python is used.