### PR TITLE
Update Makefile to use latexmk, and some minor improvements to the basic concepts section

### DIFF
--- a/.github/workflows/build-slides.yml
+++ b/.github/workflows/build-slides.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           root_file: C++Course.tex
           latexmk_shell_escape: true
-          args: -pdf -interaction=nonstopmode
+          args: -pdf -interaction=nonstopmode -halt-on-error
           working_directory: talk
           extra_system_packages: "py-pygments"
       - name: Upload PDF as artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,6 @@
 # latex related, Course
-talk/*aux
-talk/*/*aux
-C++Course.log
-C++Course.nav
-C++Course.out
-C++Course.snm
-C++Course.toc
-C++Course.vrb
-C++Course.xdv
-C++Course.pdf
-C++Course*.vrb
-C++Course.fdb_latexmk
-C++Course.fls
+C++Course.*
+!C++Course.tex
 _minted*
 
 # latex related, exercise intro

--- a/talk/.latexmkrc
+++ b/talk/.latexmkrc
@@ -1,0 +1,1 @@
+$clean_ext = "cut lex lgb lgp mw nav snm vrb _minted-%R/* _minted-%R";

--- a/talk/Makefile
+++ b/talk/Makefile
@@ -1,19 +1,27 @@
 all: C++Course.pdf
 
-essentials:
-	ESSENTIALS=1 make
+LATEXMK=latexmk
+OPTIONS=-pdf -shell-escape -halt-on-error
 
-%.pdf: *.tex **/*.tex
-ifdef ESSENTIALS
-	echo "\basictrue" > onlybasics.tex
+essentials: all
+essentials: OPTIONS+=-pretex='\basictrue'
+
+preview: all
+preview: OPTIONS+=-pvc
+
+ifneq ($(V), 1)
+	OPTIONS+=-quiet
 else
-	rm -f onlybasics.tex
+	OPTIONS+=-interaction=nonstopmode
 endif
-	pdflatex -shell-escape C++Course.tex
-	pdflatex -shell-escape C++Course.tex
+
+.PHONY: clean clobber FORCE
+
+%.pdf: %.tex FORCE
+	$(LATEXMK) $(OPTIONS) $<
 
 clean:
-	rm -rf *.aux */*.aux *.log *.nav *.out *.pyg *.snm *.vrb *.toc C++Course.l* _minted-C++Course
+	$(LATEXMK) -quiet -c
 
-clobber: clean
-	rm -f C++Course.pdf
+clobber:
+	$(LATEXMK) -quiet -C

--- a/talk/basicconcepts/assert.tex
+++ b/talk/basicconcepts/assert.tex
@@ -77,7 +77,7 @@ Abort trap: 6
     \begin{cppcode*}{}
       double f(UserType a) {
         static_assert(
-          std::is_floating_point_v<UserType>,
+          std::is_floating_point<UserType>::value,
           "This function expects floating-point types.");
         return std::sqrt(a);
       }
@@ -89,7 +89,7 @@ a.cpp: In function 'double f(UserType)':
 \textcolor{blue}{a.cpp:3:9:} \textcolor{red}{error:} \textcolor{blue}{static assertion failed: This function}
                                            \textcolor{blue}{expects floating-point types.}
    2 | static_assert(
-     |   \textcolor{red}{std::is_floating_point_v<UserType>},
-     |   \textcolor{red}{~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~}
+     |   \textcolor{red}{std::is_floating_point<UserType>::value},
+     |   \textcolor{red}{~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~}
   \end{Verbatim}
 \end{frame}

--- a/talk/basicconcepts/assert.tex
+++ b/talk/basicconcepts/assert.tex
@@ -64,12 +64,12 @@ Abort trap: 6
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[17]{Static Assert}
+  \frametitlecpp[11]{Static Assert}
   \begin{block}{Checking invariants at compile time}
     \begin{itemize}
       \item To check invariants at compile time, use \mintinline{cpp}{static_assert}
       \item The assertion can be any constant expression (see later)
-      \item No runtime penalty!
+      \item The message argument is optional in \cpp 17 and later
     \end{itemize}
   \end{block}
   \begin{exampleblock}{\texttt{static\_assert}}
@@ -86,7 +86,8 @@ Abort trap: 6
   \scriptsize
   \begin{Verbatim}[commandchars=\\\{\}]
 a.cpp: In function 'double f(UserType)':
-\textcolor{blue}{a.cpp:3:9:} \textcolor{red}{error:} \textcolor{blue}{static assertion failed: This function expects floating-point types.}
+\textcolor{blue}{a.cpp:3:9:} \textcolor{red}{error:} \textcolor{blue}{static assertion failed: This function}
+                                           \textcolor{blue}{expects floating-point types.}
    2 | static_assert(
      |   \textcolor{red}{std::is_floating_point_v<UserType>},
      |   \textcolor{red}{~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~}

--- a/talk/basicconcepts/auto.tex
+++ b/talk/basicconcepts/auto.tex
@@ -4,8 +4,8 @@
   \frametitlecpp[11]{Auto keyword}
   \begin{block}{Reason of being}
     \begin{itemize}
-    \item many type declarations are redundant
-    \item and lead to compiler errors if you mess up
+    \item Many type declarations are redundant
+    \item They are also a source for compiler warnings and errors
     \end{itemize}
     \begin{cppcode*}{}
       std::vector<int> v;
@@ -30,7 +30,7 @@
   \begin{exerciseWithShortcut}{Loops, references, auto}{Loops, refs, auto}
     Familiarise yourself with range-based for loops and references
     \begin{itemize}
-      \item go to \texttt{code/loopsRefsAuto}
+      \item Go to \texttt{code/loopsRefsAuto}
       \item Look at \texttt{loopsRefsAuto.cpp}
       \item Compile it (\texttt{make}) and run the program (\texttt{./loopsRefsAuto})
       \item Work on the tasks that you find in \texttt{loopsRefsAuto.cpp}

--- a/talk/basicconcepts/auto.tex
+++ b/talk/basicconcepts/auto.tex
@@ -5,7 +5,8 @@
   \begin{block}{Reason of being}
     \begin{itemize}
     \item Many type declarations are redundant
-    \item They are also a source for compiler warnings and errors
+    \item They are often a source for compiler warnings and errors
+    \item Using auto prevents unwanted/unnecessary type conversions
     \end{itemize}
     \begin{cppcode*}{}
       std::vector<int> v;

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -62,10 +62,11 @@
     \end{cppcode*}
   \end{exampleblock}
   \pause
-  \begin{alertblock}{Do not abuse}
+  \begin{alertblock}{Do not abuse it}
     \begin{itemize}
-      \item explicit ifs are easier to read \\
-      \item use only when obvious and not nested
+      \item Explicit \mintinline{cpp}{if}s are generally easier to read
+      \item Use the ternary operator with short conditions and expressions
+      \item Avoid nesting
     \end{itemize}
   \end{alertblock}
 \end{frame}

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -91,7 +91,7 @@
   \end{block}
   \pause
   \begin{alertblock}{Use break}
-    Do not try to make use of non breaking cases
+    Avoid \mintinline{cpp}{switch} statements with fall-through cases
   \end{alertblock}
 \end{frame}
 

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -14,9 +14,9 @@
       }
     \end{cppcode*}
     \begin{itemize}
-      \item \mintinline{cpp}{else} and \mintinline{cpp}{else if} clause are optional
-      \item \mintinline{cpp}{else if} clause can be repeated
-      \item braces are optional if there is a single statement
+      \item The \mintinline{cpp}{else} and \mintinline{cpp}{else if} clauses are optional
+      \item The \mintinline{cpp}{else if} clause can be repeated
+      \item Braces are optional if there is a single statement
     \end{itemize}
   \end{block}
 \end{frame}
@@ -49,8 +49,8 @@
     \end{cppcode*}
     \vspace{-0.2cm}
     \begin{itemize}
-      \item if test is \mintinline{cpp}{true} expression1 is returned
-      \item else expression2 is returned
+      \item If test is \mintinline{cpp}{true} expression1 is returned
+      \item Else, expression2 is returned
     \end{itemize}
   \end{block}
   \pause

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -83,10 +83,10 @@
       }
     \end{cppcode*}
     \begin{itemize}
-      \item \mintinline{cpp}{break} is not mandatory but...
-      \item cases are entry points, not independent pieces
-      \item execution falls through to the next case without a \mintinline{cpp}{break}!
-      \item \mintinline{cpp}{default} may be omitted
+      \item The \mintinline{cpp}{break} statement is not mandatory but...
+      \item Cases are entry points, not independent pieces
+      \item Execution falls through to the next case without a \mintinline{cpp}{break}!
+      \item The \mintinline{cpp}{default} case may be omitted
     \end{itemize}
   \end{block}
   \pause
@@ -142,7 +142,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[17]{init-statements for if and switch}
+  \frametitlecpp[17]{Init-statements for if and switch}
   \begin{block}{}
     Allows to limit variable scope in \mintinline{cpp}{if} and \mintinline{cpp}{switch} statements
   \end{block}
@@ -176,9 +176,9 @@
     \end{cppcode*}
     \vspace{-0.2cm}
     \begin{itemize}
-      \item initializations and increments are comma separated
-      \item initializations can contain declarations
-      \item braces are optional if loop body is a single statement
+      \item Initializations and increments are comma separated
+      \item Initializations can contain declarations
+      \item Braces are optional if loop body is a single statement
     \end{itemize}
   \end{block}
   \pause
@@ -201,8 +201,8 @@
   \frametitlecpp[11]{Range-based loops}
   \begin{block}{Reason of being}
     \begin{itemize}
-    \item simplifies loops over ``ranges'' tremendously
-    \item especially with STL containers
+    \item Simplifies loops over ``ranges'' tremendously
+    \item Especially with STL containers
     \end{itemize}
   \end{block}
   \begin{block}{Syntax}
@@ -222,7 +222,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitlecpp[20]{init-statements for range-based loops}
+  \frametitlecpp[20]{Init-statements for range-based loops}
   \begin{block}{}
     Allows to limit variable scope in range-based loops
   \end{block}
@@ -257,7 +257,7 @@
       } while(condition);
     \end{cppcode*}
     \begin{itemize}
-      \item braces are optional if the body is a single statement
+      \item Braces are optional if the body is a single statement
     \end{itemize}
   \end{block}
   \pause
@@ -274,10 +274,10 @@
   \frametitlecpp[98]{Control structures: jump statements}
   \begin{block}{}
     \begin{description}
-    \item[break] exits the loop and continues after it
-    \item[continue] goes immediately to next loop iteration
-    \item[return] exists the current function
-    \item[goto] can jump anywhere inside a function, don't use!
+    \item[break] Exits the loop and continues after it
+    \item[continue] Goes immediately to next loop iteration
+    \item[return] Exits the current function
+    \item[goto] Can jump anywhere inside a function, avoid!
     \end{description}
   \end{block}
   \pause

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -74,7 +74,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{Control structures: switch}
   \begin{block}{Syntax}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{gobble=0}
       switch(identifier) {
         case c1 : statements1; break;
         case c2 : statements2; break;

--- a/talk/basicconcepts/functions.tex
+++ b/talk/basicconcepts/functions.tex
@@ -89,7 +89,7 @@ printBSp(s); // no copy
     \columnbreak
     \null \vfill
     \begin{tikzpicture}
-      \memorystack[word size=1, nb blocks=7, size x=3cm]
+      \memorystack[word size=1, block size=80, nb blocks=7, size x=3cm]
       \onslide<2-> {
         \memorypush{s1}
         \memorypush{...}

--- a/talk/basicconcepts/functions.tex
+++ b/talk/basicconcepts/functions.tex
@@ -181,11 +181,11 @@ changeSS2(s);
   \frametitlecpp[98]{Pass by value, reference or pointer}
   \begin{block}{Different ways to pass arguments to a function}
     \begin{itemize}
-    \item by default, arguments are passed by value (= copy) \\
+    \item By default, arguments are passed by value (= copy) \\
           good for small types, e.g.\ numbers
-    \item prefer references for mandatory parameters to avoid copies
-    \item use pointers for optional parameters to allow \mintinline{cpp}{nullptr}
-    \item use \mintinline{cpp}{const} for safety and readability whenever possible
+    \item Prefer references for mandatory parameters to avoid copies
+    \item Use pointers for optional parameters to allow \mintinline{cpp}{nullptr}
+    \item Use \mintinline{cpp}{const} for safety and readability whenever possible
     \end{itemize}
   \end{block}
   \pause
@@ -205,7 +205,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
   \begin{exercise}{Functions}
     Familiarise yourself with pass by value / pass by reference.
     \begin{itemize}
-      \item go to \texttt{code/functions}
+      \item Go to \texttt{code/functions}
       \item Look at \texttt{functions.cpp}
       \item Compile it (\texttt{make}) and run the program (\texttt{./functions})
       \item Work on the tasks that you find in \texttt{functions.cpp}

--- a/talk/basicconcepts/headersinterfaces.tex
+++ b/talk/basicconcepts/headersinterfaces.tex
@@ -5,8 +5,8 @@
   \begin{block}{Interface}
     Set of declarations defining some functionality
     \begin{itemize}
-    \item put in a so-called ``header file''
-    \item the implementation exists somewhere else
+    \item Put in a so-called ``header file''
+    \item The implementation exists somewhere else
     \end{itemize}
   \end{block}
   \begin{block}{Header : hello.hpp}
@@ -43,8 +43,8 @@
   \pause
   \begin{block}{Use only in very restricted cases}
     \begin{itemize}
-    \item inclusion of headers
-    \item customization for specific compilers/platforms
+    \item Conditional inclusion of headers
+    \item Customization for specific compilers/platforms
     \end{itemize}
   \end{block}
 \end{frame}
@@ -53,9 +53,9 @@
   \frametitlecpp[98]{Header include guards}
   \begin{block}{Problem: redefinition by accident}
     \begin{itemize}
-      \item a header may define new names (e.g.\ types)
-      \item multiple (transitive) inclusions of a header would define those names multiple times, which is a compile error
-      \item solution: guard the content of your headers!
+      \item Headers may define new names (e.g.\ types)
+      \item Multiple (transitive) inclusions of a header would define those names multiple times, which is a compile error
+      \item Solution: guard the content of your headers!
     \end{itemize}
   \end{block}
   \begin{block}{Include guards}

--- a/talk/basicconcepts/inline.tex
+++ b/talk/basicconcepts/inline.tex
@@ -4,22 +4,19 @@
   \frametitlecpp[98]{Inline keyword}
   \begin{block}{Inline functions originally}
     \begin{itemize}
-      \item applies to a function to tell the compiler to inline it
+      \item Applies to a function to tell the compiler to inline it
         \begin{itemize}
-        \item i.e. replace function calls by the function's content
-        \item similar to a macro
+        \item That is, replace function calls by the function's content\\
+              (similar to how a macro works)
         \end{itemize}
-      \item only a hint, compiler can still choose to not inline
-      \item avoids function call overhead
-        \begin{itemize}
-        \item but may increase executable size
-        \end{itemize}
+      \item Only a hint, compiler can still choose to not inline
+      \item Avoids call overhead at the cost of increasing binary size
     \end{itemize}
   \end{block}
   \begin{exampleblock}{Major side effect}
     \begin{itemize}
-      \item the linker reduces the duplicated functions into one
-      \item an inline function definition can thus live in header files
+      \item The linker reduces the duplicated functions into one
+      \item An inline function definition can thus live in header files
     \end{itemize}
   \end{exampleblock}
   \begin{block}{}
@@ -35,16 +32,16 @@
   \frametitlecpp[98]{Inline keyword}
   \begin{block}{Inline functions nowadays}
     \begin{itemize}
-      \item compilers can judge far better when to inline or not
+      \item Compilers can judge far better when to inline or not
         \begin{itemize}
         \item thus primary purpose is gone
         \end{itemize}
-      \item putting functions into headers became main purpose
-      \item many types of functions are marked \mintinline{cpp}{inline} by default:
+      \item Putting functions into headers became main purpose
+      \item Many types of functions are marked \mintinline{cpp}{inline} by default:
       \begin{itemize}
-        \item class member functions
         \item function templates
         \item \mintinline{cpp}{constexpr} functions
+        \item class member functions
       \end{itemize}
     \end{itemize}
   \end{block}
@@ -54,9 +51,9 @@
   \frametitlecpp[17]{Inline keyword}
   \begin{block}{Inline variables}
     \begin{itemize}
-      \item a global (or \mintinline{cpp}{static} member) variable specified as \mintinline{cpp}{inline}
-      \item same side effect, linker merges all occurrences into one
-      \item allows to define global variables/constants in headers
+      \item Global (or \mintinline{cpp}{static} member) variable specified as \mintinline{cpp}{inline}
+      \item Same side effect, linker merges all occurrences into one
+      \item Allows to define global variables/constants in headers
     \end{itemize}
   \end{block}
   \begin{block}{}
@@ -75,7 +72,7 @@
   \end{block}
   \begin{alertblock}{}
     \begin{itemize}
-      \item Avoid global variables! Constants are fine.
+      \item Avoid global variables! Global constants are fine.
     \end{itemize}
   \end{alertblock}
 \end{frame}

--- a/talk/basicconcepts/references.tex
+++ b/talk/basicconcepts/references.tex
@@ -29,16 +29,16 @@
   \frametitlecpp[98]{Pointers vs References}
   \begin{block}{Specificities of reference}
     \begin{itemize}
-    \item natural syntax
-    \item must be assigned when defined, cannot be \mintinline{cpp}{nullptr}
-    \item cannot be reassigned
-    \item non-const references to temporary objects are not allowed
+    \item Natural syntax
+    \item Must be assigned when defined, cannot be \mintinline{cpp}{nullptr}
+    \item Cannot be reassigned
+    \item Non-const references to temporary objects are not allowed
     \end{itemize}
   \end{block}
   \begin{block}{Advantages of pointers}
     \begin{itemize}
-    \item can be reassigned to point elsewhere or to \mintinline{cpp}{nullptr}
-    \item clearly indicates that argument may be modified
+    \item Can be reassigned to point elsewhere or to \mintinline{cpp}{nullptr}
+    \item Clearly indicates that argument may be modified
     \end{itemize}
   \end{block}
   \pause

--- a/talk/basicconcepts/references.tex
+++ b/talk/basicconcepts/references.tex
@@ -30,23 +30,22 @@
   \begin{block}{Specificities of reference}
     \begin{itemize}
     \item Natural syntax
-    \item Must be assigned when defined, cannot be \mintinline{cpp}{nullptr}
-    \item Cannot be reassigned
-    \item Non-const references to temporary objects are not allowed
+    \item Cannot be \mintinline{cpp}{nullptr}
+    \item Must be assigned when defined, cannot be reassigned
+    \item References to temporary objects must be \mintinline{cpp}{const}
     \end{itemize}
   \end{block}
   \begin{block}{Advantages of pointers}
     \begin{itemize}
-    \item Can be reassigned to point elsewhere or to \mintinline{cpp}{nullptr}
-    \item Clearly indicates that argument may be modified
+    \item Can be \mintinline{cpp}{nullptr}
+    \item Can be initialized after declaration, can be reassigned
     \end{itemize}
   \end{block}
   \pause
   \begin{goodpractice}{References}
     \begin{itemize}
-      \item Always use references when you can
-      \item Consider that a referenced object can be modified
-      \item Use \mintinline{cpp}{const} when it's not the case
+      \item Prefer using references instead of pointers
+      \item Mark references \mintinline{cpp}{const} to prevent modification
     \end{itemize}
   \end{goodpractice}
 \end{frame}

--- a/talk/introduction/history.tex
+++ b/talk/introduction/history.tex
@@ -49,6 +49,8 @@
       edge[transverse] (C++98);
       \node[new] (C17) [below of=C11,node distance=1.8cm] {C17}
       edge[direct] (C11);
+      \node[new] (C23) [below of=C17,node distance=1.2cm] {C23}
+      edge[direct] (C17);
       \node[new] (C++14) [below of=C++11] {\cpp14}
       edge[direct] (C++11);
       \node[left of=C++14,node distance=1.5cm] {2014};

--- a/talk/introduction/history.tex
+++ b/talk/introduction/history.tex
@@ -47,7 +47,7 @@
       \node[new] (C11) [below of=C99] {C11}
       edge[direct] (C99)
       edge[transverse] (C++98);
-      \node[new] (C18) [below of=C11,node distance=1.8cm] {C18}
+      \node[new] (C17) [below of=C11,node distance=1.8cm] {C17}
       edge[direct] (C11);
       \node[new] (C++14) [below of=C++11] {\cpp14}
       edge[direct] (C++11);

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -92,6 +92,10 @@
 \usepackage{comment}
 \usepackage{totcount}
 
+% Use C++Course.cut for output so it's cleaned by latexmk
+\def\DefaultCutFileName{\def\CommentCutFile{\jobname.cut}}
+\DefaultCutFileName
+
 %%%%%%%%%%%%%%%%%%%
 % useful commands %
 %%%%%%%%%%%%%%%%%%%

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -201,7 +201,7 @@
 \resetcounteronoverlays{gb@counter}
 \newcommand*{\overlaynumber}{\number\beamer@slideinframe}
 
-% Use as \godbolLink{url}
+% Use as \godboltLink{url}
 \newcommand\godboltLink[2]{%
   \href{#1}{\color{blue!50!white} godbolt}%
   \ifnum \overlaynumber=1%

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -46,6 +46,7 @@
 % packages %
 %%%%%%%%%%%%
 
+\usepackage{morewrites}
 \usepackage[utf8]{inputenc}
 \usepackage{newunicodechar}
 \usepackage{scontents}

--- a/talk/tools/editors.tex
+++ b/talk/tools/editors.tex
@@ -4,23 +4,23 @@
   \frametitle{\cpp editors and IDEs}
   \begin{block}{Can dramatically improve your efficiency by}
     \begin{itemize}
-      \item coloring the code for you to ``see'' the structure
-      \item helping with indenting and formatting properly
-      \item allowing you to easily navigate in the source tree
-      \item helping with compilation/debugging, profiling, static analysis
-      \item showing you errors and suggestions while typing
+      \item Coloring the code for you to ``see'' the structure
+      \item Helping with indenting and formatting properly
+      \item Allowing you to easily navigate in the source tree
+      \item Helping with compilation/debugging, profiling, static analysis
+      \item Showing you errors and suggestions while typing
     \end{itemize}
   \end{block}
   \begin{block}{}
     \begin{description}
     \item[\href{http://www.microsoft.com/}{\beamergotobutton{Visual Studio}}]
-      heavy, fully fledged IDE for Windows
+      Heavy, fully fledged IDE for Windows
     \item[\href{https://code.visualstudio.com/}{\beamergotobutton{Visual Studio Code}}]
-      editor, open source, portable, many plugins
+      Editor, open source, portable, many plugins
     \item[\href{https://www.eclipse.org/}{\beamergotobutton{Eclipse}}]
       IDE, open source, portable
     \item[\href{http://www.gnu.org/software/emacs/}{\beamergotobutton{Emacs}} \href{https://www.vim.org/}{\beamergotobutton{Vim}}]
-      editors for experts, extremely powerful. \\
+      Editors for experts, extremely powerful. \\
       They are to IDEs what latex is to PowerPoint
     \item[CLion, Code::Blocks, Atom, NetBeans, Sublime Text, ...]
     \end{description}

--- a/talk/tools/formatting.tex
+++ b/talk/tools/formatting.tex
@@ -4,11 +4,11 @@
 \frametitle{clang-format}
 \begin{block}{.clang-format}
 	\begin{itemize}
-		\item file describing your formatting preferences
-		\item should be checked-in at the repository root (project wide)
+		\item File describing your formatting preferences
+		\item Should be checked-in at the repository root (project wide)
 		\item \mintinline{bash}{clang-format -style=LLVM -dump-config >} \\
 		  \mintinline{bash}{.clang-format}
-		\item adapt style options with help from: \url{https://clang.llvm.org/docs/ClangFormatStyleOptions.html}
+		\item Adapt style options with help from: \url{https://clang.llvm.org/docs/ClangFormatStyleOptions.html}
 	\end{itemize}
 \end{block}
 \begin{block}{Run clang-format}
@@ -26,15 +26,15 @@
 \frametitle{clang-format}
 \begin{exercise}{clang-format}
 	\begin{itemize}
-		\item go to any example
-		\item format code with: \mintinline{bash}{clang-format --style=GNU -i <file.cpp>}
-		\item inspect changes, try \mintinline{bash}{git diff .}
-		\item revert changes using \mintinline{bash}{git checkout -- <file.cpp>} or \mintinline{bash}{git checkout .}
-		\item go to code directory and create a .clang-format file \\
+		\item Go to any example
+		\item Format code with: \mintinline{bash}{clang-format --style=GNU -i <file.cpp>}
+		\item Inspect changes, try \mintinline{bash}{git diff .}
+		\item Revert changes using \mintinline{bash}{git checkout -- <file.cpp>} or \mintinline{bash}{git checkout .}
+		\item Go to code directory and create a .clang-format file \\
 		  \mintinline{bash}{clang-format -style=LLVM -dump-config >} \\
 		  \mintinline{bash}{.clang-format}
-		\item run \mintinline{bash}{clang-format -i <any_exercise>/*.cpp}
-		\item revert changes using \mintinline{bash}{git checkout <any_exercise>}
+		\item Run \mintinline{bash}{clang-format -i <any_exercise>/*.cpp}
+		\item Revert changes using \mintinline{bash}{git checkout <any_exercise>}
 	\end{itemize}
 \end{exercise}
 \end{frame}

--- a/talk/tools/vcs.tex
+++ b/talk/tools/vcs.tex
@@ -4,9 +4,9 @@
   \frametitle{Code management tool}
   \begin{alertblock}{Please use one!}
     \begin{itemize}
-    \item even locally
-    \item even on a single file
-    \item even if you are the only committer
+    \item Even locally
+    \item Even on a single file
+    \item Even if you are the only committer
     \end{itemize}
     It will soon save your day
   \end{alertblock}
@@ -15,7 +15,7 @@
     \item[\href{http://git-scm.com/}{\beamergotobutton{git}}]
       THE mainstream choice. Fast, light, easy to use
     \item[\href{http://mercurial.selenic.com/}{\beamergotobutton{mercurial}}]
-      the alternative to git
+      The alternative to git
     \item[\href{http://bazaar.canonical.com/en/}{\beamergotobutton{Bazaar}}]
       another alternative
     \item[svn]
@@ -27,7 +27,7 @@
 \end{frame}
 
 \begin{frame}[fragile]
-  \frametitle{GIT crash course}
+  \frametitle{Git crash course}
   \begin{minted}[gobble=4]{bash}
     # git init myProject
     Initialized empty Git repository in myProject/.git/

--- a/talk/tools/vcs.tex
+++ b/talk/tools/vcs.tex
@@ -17,11 +17,11 @@
     \item[\href{http://mercurial.selenic.com/}{\beamergotobutton{mercurial}}]
       The alternative to git
     \item[\href{http://bazaar.canonical.com/en/}{\beamergotobutton{Bazaar}}]
-      another alternative
-    \item[svn]
-      historical, not distributed - DO NOT USE
-    \item[CVS]
-      archeological, not distributed - DO NOT USE
+      Another alternative
+    \item[\href{https://subversion.apache.org/}{\beamergotobutton{Subversion}}]
+      Historical, not distributed - don't use
+    \item[\href{https://cvs.nongnu.org/}{\beamergotobutton{CVS}}]
+      Archeological, not distributed - don't use
     \end{description}
   \end{block}
 \end{frame}

--- a/talk/tools/vcs.tex
+++ b/talk/tools/vcs.tex
@@ -28,22 +28,22 @@
 
 \begin{frame}[fragile]
   \frametitle{Git crash course}
-  \begin{minted}[gobble=4]{bash}
-    # git init myProject
+  \begin{minted}[gobble=4]{shell-session}
+    $ git init myProject
     Initialized empty Git repository in myProject/.git/
 
-    # vim file.cpp; vim file2.cpp
-    # git add file.cpp file2.cpp
-    # git commit -m "Committing first 2 files"
+    $ vim file.cpp; vim file2.cpp
+    $ git add file.cpp file2.cpp
+    $ git commit -m "Committing first 2 files"
     [master (root-commit) c481716] Committing first 2 files
     ...
 
-    # git log --oneline
+    $ git log --oneline
     d725f2e Better STL test
     f24a6ce Reworked examples + added stl one
     bb54d15 implemented template part
     ...
 
-    # git diff f24a6ce bb54d15
+    $ git diff f24a6ce bb54d15
   \end{minted}
 \end{frame}


### PR DESCRIPTION
I added a `make preview` target to the `Makefile`, which should make it easier to avoid edit compile cycles with an appropriate viewer. On Linux, to use evince as your previewer, add the line below to `~/.latexmkrc`:
```
$pdf_previewer = "start evince"
```
I left it out of the custom config because it's likely different people will want to use different viewers.