### PR TITLE
Add slides with further resources (books and links to conferences)

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -260,4 +260,17 @@
   \end{thebibliography}
 \end{frame}
 
+\begin{frame}
+  \frametitle{Conferences}
+  \begin{itemize}
+    \item CppCon --- \href{https://cppcon.org/}{cppcon.org}
+    \item \cpp Now --- \href{https://cppnow.org/}{cppnow.org}
+    \item Code::Dive --- \href{https://codedive.pl/}{codedive.pl}
+    \item ACCU Conference --- \href{https://accu.org/}{accu.org}
+    \item Meeting \cpp\ --- \href{https://meetingcpp.com/}{meetingcpp.com}
+    \item See link below for more information
+          \url{https://isocpp.org/wiki/faq/conferences-worldwide}
+  \end{itemize}
+\end{frame}
+
 \end{document}

--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -222,4 +222,42 @@
   \listofgodbolt
 \end{frame}
 
+\section*{External Resources and Further Reading}
+
+\begin{frame}
+  \frametitle{Books}
+  \begin{thebibliography}{10}
+    \scriptsize
+    \beamertemplatebookbibitems
+
+    \bibitem{} A Tour of C++, Third Edition
+    \newblock  Bjarne Stroustrup, Addison-Wesley, Sep 2022
+    \newblock  ISBN-13: \href{https://learning.oreilly.com/library/view/a-tour-of/9780136823575/}{978-0136816485}
+
+    \bibitem{} Effective Modern C++
+    \newblock  Scott Meyers, O'Reilly Media, Nov 2014
+    \newblock  ISBN-13: \href{https://learning.oreilly.com/library/view/effective-modern-c/9781491908419/}{978-1-491-90399-5}
+
+    \bibitem{} C++ Templates - The Complete Guide, 2nd Edition
+    \newblock  David Vandevoorde, Nicolai M. Josuttis, and Douglas Gregor
+    \newblock  ISBN-13: \href{https://learning.oreilly.com/library/view/c-templates-the/9780134778808/}{978-0-321-71412-1}
+
+    \bibitem{} C++ Best Practices, 2nd Edition
+    \newblock  Jason Turner
+    \newblock  \url{https://leanpub.com/cppbestpractices}
+
+    \bibitem{} Clean Architecture
+    \newblock  Robert C. Martin, Pearson, Sep 2017
+    \newblock  ISBN-13: \href{https://learning.oreilly.com/library/view/clean-architecture-a/9780134494272/}{978-0-13-449416-6}
+
+    \bibitem{} The Art of UNIX Programming
+    \newblock  Eric S. Raymond, Addison-Wesley, Sep 2002
+    \newblock  ISBN-13: \href{https://learning.oreilly.com/library/view/the-art-of/0131429019/}{978-0131429017}
+
+    \bibitem{} Introduction to Algorithms, 4th Edition
+    \newblock  T. H. Cormen, C. E. Leiserson, R. L. Rivest, C. Stein, Apr 2022
+    \newblock  ISBN-13: \href{https://mitpress.mit.edu/9780262046305/introduction-to-algorithms/}{978-0262046305}
+  \end{thebibliography}
+\end{frame}
+
 \end{document}


### PR DESCRIPTION
This is meant to address #135, at least partially. I've added a few books I thought made sense, and some links to conferences. Let me know which books/links to add/remove, I'm opening this as draft just to get things going. I saw CMake docs were mentioned in the original issue, but I guess we'd need an extra slide, as it didn't really fit with books/conferences. I also wonder if we should have a slide with YouTube channels or not.