### PR TITLE
Improve race exercise.

### DIFF
--- a/code/race/Makefile
+++ b/code/race/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f *o $(PROGRAM_NAME) *~ core $(PROGRAM_NAME).sol
 
 $(PROGRAM_NAME) : $(PROGRAM_NAME).cpp
-	${CXX} -g -std=c++17 -O2 -pthread -Wall -Wextra -L. -o $@ $<
+	${CXX} ${CXXFLAGS} -g -std=c++17 -O2 -pthread -Wall -Wextra -L. -o $@ $<
 
 $(PROGRAM_NAME).sol : solution/$(PROGRAM_NAME).sol.cpp
-	${CXX} -g -std=c++17 -O2 -pthread -Wall -Wextra -L. -o $@ $<
+	${CXX} ${CXXFLAGS} -g -std=c++17 -O2 -pthread -Wall -Wextra -L. -o $@ $<

--- a/code/race/README.md
+++ b/code/race/README.md
@@ -1,9 +1,12 @@
 
 ## Instructions
 
-* Compile, run many times, see what happens
-    * E.g. in bash, use: `while true; do ./racing; done`
-* (Optional) You can use `valgrind --tool=helgrind ./racing` to proof your assumption
+* Compile and run the executable, see if it races
+    * If you have a bash shell, try `./run ./racing`, which keeps invoking the executable
+      until a race condition is detected
+* (Optional) You can use `valgrind --tool=helgrind ./racing` to prove your assumption
+* (Optional) If your operating system supports it, recompile with thread sanitizer.
+  With Makefile, use e.g. `make CXXFLAGS="-fsanitize=thread"`
 * Use a mutex to fix the issue
 * See the difference in execution time
-* (Optional) Check agan with `valgrind` if the problem is fixed
+* (Optional) Check again with `valgrind` or thread sanitizer if the problem is fixed

--- a/code/race/racing.cpp
+++ b/code/race/racing.cpp
@@ -1,10 +1,16 @@
 #include <iostream>
 #include <thread>
+#include <vector>
 
 /*
- * This program tries to increment an integer 200 times in two threads.
- * Check whether the result is indeed always 200.
+ * This program tries to increment an integer 100 times from multiple threads.
+ * If the result comes out at 100*nThread, it stays silent, but it will print
+ * an error if a race condition is detected.
+ * If you don't see it racing, try ./run ./racing, which keeps invoking the
+ * executable until a race condition is detected.
  */
+
+constexpr unsigned int nThread = 2;
 
 int main() {
   int nError = 0;
@@ -19,20 +25,17 @@ int main() {
       }
     };
 
-    // Run with two threads
-    std::thread t1(inc100);
-    std::thread t2(inc100);
-    for (auto t : {&t1,&t2}) t->join();
+    // Start up all threads:
+    std::vector<std::thread> threads;
+    for (unsigned int i = 0; i < nThread; ++i) threads.emplace_back(inc100);
+    for (auto & thread : threads) thread.join();
 
     // Check
-    if (a != 200) {
-      std::cout << "Race: " << a << ' ';
+    if (a != nThread * 100) {
+      std::cerr << "Race detected! Result: " << a << '\n';
       nError++;
-    } else {
-      std::cout << '.';
     }
   }
-  std::cout << '\n';
 
   return nError;
 }

--- a/code/race/run
+++ b/code/race/run
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PROGRAM="./racing"
+if [ $# -ge 1 ]; then
+  PROGRAM=$1
+fi
+
+while true; do
+  $PROGRAM || break;
+done

--- a/code/race/solution/racing.sol.cpp
+++ b/code/race/solution/racing.sol.cpp
@@ -1,11 +1,17 @@
 #include <iostream>
 #include <thread>
+#include <vector>
 #include <mutex>
 
 /*
- * This program tries to increment an integer 200 times in two threads.
- * We fix the race condition by locking a mutex before each increment.
+ * This program tries to increment an integer 100 times from multiple threads.
+ * If the result comes out at 100*nThread, it stays silent, but it will print
+ * an error if a race condition is detected.
+ * To run it in a loop, use
+ *   ./run ./racing.sol
  */
+
+constexpr unsigned int nThread = 2;
 
 int main() {
   int nError = 0;
@@ -22,20 +28,17 @@ int main() {
       }
     };
 
-    // Run with two threads
-    std::thread t1(inc100);
-    std::thread t2(inc100);
-    for (auto t : {&t1,&t2}) t->join();
+    // Start up all threads:
+    std::vector<std::thread> threads;
+    for (unsigned int i = 0; i < nThread; ++i) threads.emplace_back(inc100);
+    for (auto & thread : threads) thread.join();
 
     // Check
-    if (a != 200) {
-      std::cout << "Race: " << a << ' ';
+    if (a != nThread * 100) {
+      std::cerr << "Race detected! Result: " << a << '\n';
       nError++;
-    } else {
-      std::cout << '.';
     }
   }
-  std::cout << '\n';
 
   return nError;
 }


### PR DESCRIPTION
The race exercise races very infrequently on some platforms. Therefore:
- Provide a variable to spawn more threads
- Provide a run script that invokes the executable until a race occurs
- Add thread sanitizer and valgrind as optional steps to the instructions

Fix #353.