### PR TITLE
Use accumulate over reduce when necessary

### DIFF
--- a/code/header_units/main.cpp
+++ b/code/header_units/main.cpp
@@ -24,9 +24,9 @@ void compute(int len, T initial, T step) {
     std::adjacent_difference(v.begin(), v.end(), diffs.begin());
 
     // compute standard deviation of it
-    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
-    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
-                                [](const T& s, const T& a) { return s + a * a; });
+    const T sum = std::reduce(diffs.begin()+1, diffs.end());
+    const T sumsq = std::accumulate(diffs.begin()+1, diffs.end(), T(),
+                                    [](const T& s, const T& a) { return s + a * a; });
     const T mean = sum/len;
     const T variance = sumsq/len - mean*mean;
 

--- a/code/header_units/solution/main.cpp
+++ b/code/header_units/solution/main.cpp
@@ -22,9 +22,9 @@ void compute(int len, T initial, T step) {
     std::adjacent_difference(v.begin(), v.end(), diffs.begin());
 
     // compute standard deviation of it
-    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
-    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
-                                [](const T& s, const T& a) { return s + a * a; });
+    const T sum = std::reduce(diffs.begin()+1, diffs.end());
+    const T sumsq = std::accumulate(diffs.begin()+1, diffs.end(), T(),
+                                    [](const T& s, const T& a) { return s + a * a; });
     const T mean = sum/len;
     const T variance = sumsq/len - mean*mean;
 

--- a/code/modules/main.cpp
+++ b/code/modules/main.cpp
@@ -24,9 +24,9 @@ void compute(int len, T initial, T step) {
     std::adjacent_difference(v.begin(), v.end(), diffs.begin());
 
     // compute standard deviation of it
-    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
-    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
-                                [](const T& s, const T& a) { return s + a * a; });
+    const T sum = std::reduce(diffs.begin()+1, diffs.end());
+    const T sumsq = std::accumulate(diffs.begin()+1, diffs.end(), T(),
+                                    [](const T& s, const T& a) { return s + a * a; });
     const T mean = sum/len;
     const T variance = sumsq/len - mean*mean;
 

--- a/code/modules/solution/main.cpp
+++ b/code/modules/solution/main.cpp
@@ -25,9 +25,9 @@ void compute(int len, T initial, T step) {
     std::adjacent_difference(v.begin(), v.end(), diffs.begin());
 
     // compute standard deviation of it
-    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
-    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
-                                [](const T& s, const T& a) { return s + a * a; });
+    const T sum = std::reduce(diffs.begin()+1, diffs.end());
+    const T sumsq = std::accumulate(diffs.begin()+1, diffs.end(), T(),
+                                    [](const T& s, const T& a) { return s + a * a; });
     const T mean = sum/len;
     const T variance = sumsq/len - mean*mean;
 

--- a/code/smartPointers/smartPointers.cpp
+++ b/code/smartPointers/smartPointers.cpp
@@ -39,7 +39,7 @@ double sumEntries(std::span<double const> range) {
     // Simulate an error
     throw std::invalid_argument("Error when summing over data.");
 
-    return std::reduce(range.begin(), range.end(), 0.);
+    return std::reduce(range.begin(), range.end());
 }
 
 // Often, data are owned by one entity, and merely used by others. In this case, we hand the data to

--- a/code/smartPointers/solution/smartPointers.sol.cpp
+++ b/code/smartPointers/solution/smartPointers.sol.cpp
@@ -40,7 +40,7 @@ double sumEntries(std::span<double const> range) {
     // Simulate an error
     throw std::invalid_argument("Error when summing over data.");
 
-    return std::reduce(range.begin(), range.end(), 0.);
+    return std::reduce(range.begin(), range.end());
 }
 
 // Often, data are owned by one entity, and merely used by others. In this case, we hand the data to

--- a/code/stl/randomize.cpp
+++ b/code/stl/randomize.cpp
@@ -19,7 +19,7 @@ void compute(int len, T initial, T step) {
 
     // compute standard deviation of all differences
     const T sum = std::reduce(...);
-    const T sumsq = std::reduce(..., [](...) { ...; });
+    const T sumsq = std::accumulate(..., [](...) { ...; });
     const T mean = sum/len;
     const T variance = sumsq/len - mean*mean;
 

--- a/code/stl/solution/randomize.sol.cpp
+++ b/code/stl/solution/randomize.sol.cpp
@@ -42,11 +42,11 @@ void compute(int len, T initial, T step) {
 
     // compute standard deviation of all differences.
     // Note that the first element is just the original element itself, so we need to skip it.
-    const T sum = std::reduce(diffs.begin()+1, diffs.end(), T());
-    const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(), sumsquare<T>());
+    const T sum = std::reduce(diffs.begin()+1, diffs.end());
+    const T sumsq = std::accumulate(diffs.begin()+1, diffs.end(), T(), sumsquare<T>());
     // Alternatively:
-    // const T sumsq = std::reduce(diffs.begin()+1, diffs.end(), T(),
-    //                             [](const T& s, const T& a) { return s + a * a; });
+    // const T sumsq = std::accumulate(diffs.begin()+1, diffs.end(), T(),
+    //                                 [](const T& s, const T& a) { return s + a * a; });
     const T mean = sum/len;
     const T variance = sumsq/len - mean*mean;
 


### PR DESCRIPTION
`std::reduce` can only be used over `std::accumulate` when the binary operation is commutative and associative. This does not hold for the exercises computing squared sums, so `std::reduce` is a bug there.