### PR TITLE
Sync all compiler exercise instructions

### DIFF
--- a/code/ExerciseSchedule_EssentialCourse.md
+++ b/code/ExerciseSchedule_EssentialCourse.md
@@ -25,7 +25,7 @@ Day 2 - Tools Exercises
 The tools exercises of day 2 are special as they will have been played (quickly) during the course.
 People should replay them and discover the tools by themselves.
 
-### Compiler (directory: [`functions`](functions), [CheatSheet](ExercisesCheatSheet.md#compiler))
+### Compiler (directory: [`polymorphism`](polymorphism), [CheatSheet](ExercisesCheatSheet.md#compiler))
 
 ### Debugging (directory: [`debug`](debug), [CheatSheet](ExercisesCheatSheet.md#debugging-directory-debug))
 

--- a/code/ExercisesCheatSheet.md
+++ b/code/ExercisesCheatSheet.md
@@ -254,13 +254,15 @@ Steps:
 7. Revert changes using `git checkout <any_exercise>`
 8. Please advise the students they should use `.clang-format` files from their projects before they start developing their own one.
 
-### Compiler (directory: [`functions`](functions))
+### Compiler (directory: [`polymorphism`](polymorphism))
 
-Based on the functions exercise, we are replaying the compilation steps manually.
+We replay the compilation steps manually.
+Concrete details in the polymorphism README.md.
 
-A "break the ice" exercise here would be to ask people to do the first step (preprocessor) and make a poll on how many lines of C++ are present in the output. It will vary depending on setups, versions, OS, etc...
+A "break the ice" exercise here would be to ask people to do the first step (preprocessor) and make a poll on how many lines of C++ are present in the output.
+It will vary depending on setups, versions, OS, etc...
 
-Then the important part is to play with nm and the -C option of C++filt to be able to decode symbols, find them and thus address a build error that mentions missing symbols.
+Then the important part is to play with `nm` and the `-C` option of `C++filt` to be able to decode symbols, find them and thus address a build error that mentions missing symbols.
 
 Another important bit is ldd and inspecting library dependencies.
 

--- a/code/polymorphism/README.md
+++ b/code/polymorphism/README.md
@@ -20,13 +20,14 @@ Step 2
 
 ## Instructions for the "compiler chain" exercise
 
-* preprocess `Polygons.cpp` (`cpp` or `gcc -E -o output`)
+* preprocess `Polygons.cpp` (`g++ -E -o output`)
 * compile `Polygons.o` and `trypoly.o` (`g++ -c -o output`)
-* use `nm` to check symbols in '.o' files
+* use `nm` to check symbols in `.o` files
 * look at the `Makefile`
 * try `make clean; make`
 * see linking stage using `g++ -v`
-  * just add a -v in the Makefile command for trypoly
-  * run make clean; make
-  * look at the collect 2 line, from the end up to '-o trypoly'
-* see library dependencies with `ldd`
+  * just add a `-v` in the Makefile command for `trypoly`
+  * run `make clean; make`
+  * look at the collect 2 line, from the end up to `-o trypoly`
+* see library dependencies of `trypoly` and `Polygons.so` with `ldd`
+  * On OS X, use `otool -L` for a similar effect

--- a/talk/tools/compiling.tex
+++ b/talk/tools/compiling.tex
@@ -212,19 +212,19 @@
   \frametitle{Compiler chain}
   \begin{exercise}{Compiler chain}
     \begin{itemize}
-    \item go to code/functions
-    \item preprocess functions.cpp (cpp or gcc -E -o output)
-    \item compile functions.o and Structs.o (g++ -c -o output)
+    \item go to code/polymorphism
+    \item preprocess Polygons.cpp (g++ -E -o output)
+    \item compile Polygons.o and trypoly.o (g++ -c -o output)
     \item use nm to check symbols in .o files
     \item look at the Makefile
     \item try make clean; make
     \item see linking stage of the final program using g++ -v
       \begin{itemize}
-      \item just add a -v in the Makefile command for functions target
+      \item just add a -v in the Makefile command for trypoly target
       \item run make clean; make
-      \item look at the collect 2 line, from the end up to ``-o functions''
+      \item look at the collect 2 line, from the end up to ``-o trypoly''
       \end{itemize}
-    \item see library dependencies with `ldd functions`
+    \item see library dependencies of `trypoly` using `ldd`
     \end{itemize}
   \end{exercise}
 \end{frame}


### PR DESCRIPTION
~I am really confused now. The slides say the compiler exercise uses the `functions` exercise. But the `polymorphism` exercise has the instructions for the exercise. Which one is not the right one?~

The compiler exercise is now done again on the polymorphism exercise. This was changed in 696cd88 from PR #88 to the functions exercise, so the tools can be discussed even if the OO part was not discussed yet. However, the polymorphism exercise is better since it involves a shared library.