### PR TITLE
Rename core modern C++ chapter to more language

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -131,7 +131,7 @@
   \input{objectorientation/adl}
 \end{advanced}
 
-\section[More]{Core modern \cpp}
+\section[More]{More language}
 \input{morelanguage/constness}
 \begin{advanced}
   \input{morelanguage/constexpr}


### PR DESCRIPTION
Because the chapter is mostly about more language features. I would consider max. half of it "modern C++" in the sense of being C++11 and newer, so I think it does not justify the title.
