### PR TITLE
Allow for choosing essentials vs full via environment variable.

### DIFF
--- a/.github/workflows/build-slides.yml
+++ b/.github/workflows/build-slides.yml
@@ -22,11 +22,18 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v3
-      - name: Set up essentials course
-        if: matrix.version == 'essentials'
-        run: echo '\basictrue' > talk/onlybasics.tex
-      - name: Compile LaTeX document
+      - name: Compile essentials
         uses: xu-cheng/latex-action@v2
+        if: matrix.version == 'essentials'
+        with:
+          root_file: C++Course.tex
+          latexmk_shell_escape: true
+          args: -pdf -interaction=nonstopmode -halt-on-error -usepretex=\def\makebasic{}
+          working_directory: talk
+          extra_system_packages: "py-pygments"
+      - name: Compile full course
+        uses: xu-cheng/latex-action@v2
+        if: matrix.version == 'full'
         with:
           root_file: C++Course.tex
           latexmk_shell_escape: true

--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -8,18 +8,18 @@
 % create a new latex if called basic (false by default)
 \newif\ifbasic
 
-% There are two ways to switch to the basic course:
-% 1. Uncomment the following line:
+% There are three ways to switch to the basic course:
+% 1. Uncomment the line below. Disadvantage: git diff won't be empty
 %\basictrue
-
-% 2. Define the makebasic macro from the outside.
-% This could be done using -usepretex=\def\makebasic{}
-% The above is used:
-% - when invoking "make essentials"
-% - when exporting HEPCPP_ESSENTIALS=1
+% 2. Tell it to the Makefile.
+%  2.1 Invoke "make essentials"
+%  2.2 export HEPCPP_ESSENTIALS=1
+%      make <target>
 \ifdefined\makebasic
   \basictrue
 \fi
+% 3. Create a file named ./buildbasic
+\IfFileExists{./buildbasic}{\basictrue}
 
 % create a comment environment advanced. depending on the value of basic, we exclude or include it.
 \ifbasic

--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -7,8 +7,19 @@
 % setup for the basic/advanced course switch
 % create a new latex if called basic (false by default)
 \newif\ifbasic
-%\basictrue % uncomment to make basic true
-\IfFileExists{onlybasics.tex}{\input{onlybasics}}{}
+
+% There are two ways to switch to the basic course:
+% 1. Uncomment the following line:
+%\basictrue
+
+% 2. Define the makebasic macro from the outside.
+% This could be done using -usepretex=\def\makebasic{}
+% The above is used:
+% - when invoking "make essentials"
+% - when exporting HEPCPP_ESSENTIALS=1
+\ifdefined\makebasic
+  \basictrue
+\fi
 
 % create a comment environment advanced. depending on the value of basic, we exclude or include it.
 \ifbasic

--- a/talk/Makefile
+++ b/talk/Makefile
@@ -4,7 +4,7 @@ LATEXMK=latexmk
 OPTIONS=-pdf -shell-escape -halt-on-error
 
 essentials: all
-essentials: OPTIONS+=-pretex='\basictrue'
+essentials: OPTIONS+=-usepretex='\def\makebasic{}'
 
 preview: all
 preview: OPTIONS+=-pvc
@@ -13,6 +13,10 @@ ifeq ($(QUIET), 1)
 	OPTIONS+=-quiet
 else
 	OPTIONS+=-interaction=nonstopmode
+endif
+
+ifeq ($(HEPCPP_ESSENTIALS), 1)
+	OPTIONS+=-usepretex='\def\makebasic{}'
 endif
 
 .PHONY: clean clobber FORCE

--- a/talk/morelanguage/templates.tex
+++ b/talk/morelanguage/templates.tex
@@ -108,7 +108,7 @@
 
 \begin{frame}[fragile]
   \frametitlecpp[98]{Template parameters}
-  \begin{block}{\texttt{typename} vs. \texttt{class} keyword}
+  \begin{block}{\texttt{typename} vs.\ \texttt{class} keyword}
     \begin{itemize}
       \item for declaring a template type parameter,
             the \cppinline{typename} and \cppinline{class} keyword are semantically equivalent

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -92,6 +92,7 @@
 \usepackage{booktabs}
 \usepackage{comment}
 \usepackage{totcount}
+\usepackage{xspace}
 
 % Use C++Course.cut for output so it's cleaned by latexmk
 \def\DefaultCutFileName{\def\CommentCutFile{\jobname.cut}}
@@ -100,7 +101,7 @@
 %%%%%%%%%%%%%%%%%%%
 % useful commands %
 %%%%%%%%%%%%%%%%%%%
-\newcommand{\cpp}{C$^{++}$}
+\newcommand{\cpp}{C$^{++}$\xspace}
 \newcommand{\deprecated}{\textcolor{red}{\bf Deprecated}}
 \newcommand{\removed}{\textcolor{red}{\bf Removed}}
 


### PR DESCRIPTION
Here is an attempt at switching between essentials and advanced course without changing files under version control. There is many ways now to switch to essentials:
- Uncomment a line in `C++Course.tex` (but git diff won't be empty)
- `export HEPCPP_ESSENTIALS=1`
  `make`
- `make essentials`
- `touch ./buildbasic`

For details, see the code proposed in this PR:
```latex
% There are three ways to switch to the basic course:
 % 1. Uncomment the line below. Disadvantage: git diff won't be empty
 %\basictrue
 % 2. Tell it to the Makefile.
 %  2.1 Invoke "make essentials"
 %  2.2 export HEPCPP_ESSENTIALS=1
 %      make <target>
 \ifdefined\makebasic
   \basictrue
 \fi
 % 3. Create a file named ./buildbasic
 \IfFileExists{./buildbasic}{\basictrue}
```