### PR TITLE
Mention more debug symbol flags

### DIFF
--- a/talk/tools/compiling.tex
+++ b/talk/tools/compiling.tex
@@ -70,7 +70,7 @@
   \end{block}
   \begin{block}{Optimization}
     \begin{description}
-      \item[-g] add debug symbols
+      \item[-g] add debug symbols (also: \texttt{-g3} or \texttt{-ggdb})
       \item[-Ox] 0 = no opt., 1-2 = opt., 3 = highly opt. (maybe larger binary), g = opt. for debugging
     \end{description}
   \end{block}


### PR DESCRIPTION
These flags keep popping up here and there when I watch C++ talks, so I wonder whether we should mention them as well. I have not tried them myself, since cmake usually chooses `-g` for me.