### PR TITLE
Make function exercise print only 5 chars

### DIFF
--- a/code/functions/functions.cpp
+++ b/code/functions/functions.cpp
@@ -12,6 +12,7 @@
  *      argument.name[0] = 'a';
  *    to your print function.
  *    Try both with and without const attributes in your print function's signature.
+ * 5. Bonus: Can you fix "printFiveCharacters" to actually only print the first five characters and not the entire string?
  */
 
 #include "Structs.h" // The data structs we will work with
@@ -19,14 +20,14 @@
 #include <iostream> // For printing
 
 void printFiveCharacters(FastToCopy argument) {
-    std::cout << argument.name << "\n";
+    std::cout << argument.name << '\n';
 }
 
 int main() {
-    FastToCopy fast = {"abcdef"};
+    FastToCopy fast = {"abcdefghijkl"};
     printFiveCharacters(fast);
 
-    SlowToCopy slow = {"ghijkl"};
+    SlowToCopy slow = {"ABCDEFGHIJKL"};
     // print it here
 
     return 0;

--- a/code/functions/solution/functions.sol.cpp
+++ b/code/functions/solution/functions.sol.cpp
@@ -22,7 +22,7 @@ void printFiveCharacters(FastToCopy argument) {
     for (int i = 0; i < 5; i++)
         std::cout << argument.name[i];
     std::cout << '\n';
-    
+
     // alternative 1: std::cout << argument.name.substr(0, 5) << '\n';
     // alternative 2: std::cout << std::string_view{argument.name.data(), 5} << '\n';
     // alternative C: std::printf("%.5s\n", argument.name.c_str());

--- a/code/functions/solution/functions.sol.cpp
+++ b/code/functions/solution/functions.sol.cpp
@@ -19,25 +19,32 @@
 #include <iostream> // For printing
 
 void printFiveCharacters(FastToCopy argument) {
-    std::cout << argument.name << "\n";
+    for (int i = 0; i < 5; i++)
+        std::cout << argument.name[i];
+    std::cout << '\n';
+    
+    // alternative 1: std::cout << argument.name.substr(0, 5) << '\n';
+    // alternative 2: std::cout << std::string_view{argument.name.data(), 5} << '\n';
+    // alternative C: std::printf("%.5s\n", argument.name.c_str());
+    // alternative C++23: std::print("{:.5}\n", argument);
 }
 
 void printFiveCharacters(const SlowToCopy & argument) {
     //argument.data[0] = '\n' ; // EXPECTED COMPILATION ERROR
-    std::cout << argument.name << "\n";
+    std::cout << argument.name << '\n';
 }
 
 void printFiveCharactersWithCopy(SlowToCopy argument) {
-    std::cout << argument.name << "\n";
+    std::cout << argument.name << '\n';
     // We can actually modify the argument if we want, since it's a copy:
     argument.name[0] = 'a';
 }
 
 int main() {
-    FastToCopy fast = {"abcdef"};
+    FastToCopy fast = {"abcdefghijkl"};
     printFiveCharacters(fast);
 
-    SlowToCopy slow = {"ghijkl"};
+    SlowToCopy slow = {"ABCDEFGHIJKL"};
     printFiveCharacters(slow);
 
     std::cout << "Now printing with copy:\n";


### PR DESCRIPTION
This PR points out in the instructions of the functions exercise that the solution should only print 5 characters in the end. The solution is adapted with a few alternatives on how to solve this.