### PR TITLE
Small improvements found during JLab course

### DIFF
--- a/talk/morelanguage/raii.tex
+++ b/talk/morelanguage/raii.tex
@@ -37,8 +37,8 @@
       read_line(s);
       vec.push_back(s);
       set.add(s);
-      std::thread t1(func1, vec);
-      std::thread t2(func2, set);
+      std::thread t1{func1, vec};
+      std::thread t2{func2, set};
     \end{cppcode*}
   \end{exampleblock}
 \end{frame}

--- a/talk/morelanguage/stl.tex
+++ b/talk/morelanguage/stl.tex
@@ -132,7 +132,7 @@
         std::unordered_map<std::string, int> m;
         m["hello"] = 1;  // inserts new key, def. constr. value
         m["hello"] = 2;  // finds existing key
-        auto [it, isNewKey] = m.insert("hello");
+        auto [it, isNewKey] = m.insert({"hello", 0}); // no effect
         int val = m["world"];    // inserts new key (val == 0)
         int val = m.at("monde"); // throws std::out_of_range
 

--- a/talk/objectorientation/static.tex
+++ b/talk/objectorientation/static.tex
@@ -9,15 +9,35 @@
     \item identified by the \cppinline{static} keyword
     \end{itemize}
   \end{block}
+
+  \vspace{-1\baselineskip}
+  \begin{overprint}
+  \onslide<1>
+  \begin{exampleblock}{Static.hpp}
   \begin{cppcode}
     class Text {
     public:
-      static std::string upper(std::string) {...}
+      static std::string upper(std::string);
     private:
       static int callsToUpper; // add `inline` in C++17
     };
+  \end{cppcode}
+  \end{exampleblock}
+
+  \onslide<2>
+  \begin{exampleblock}{Static.cpp}
+  \begin{cppcode}
+    #include "Static.hpp"
     int Text::callsToUpper = 0; // required before C++17
+
+    std::string Text::upper(std::string lower) {
+      callsToUpper++;
+      // convert lower to upper case
+      // return ...;
+    }
     std::string uppers = Text::upper("my text");
     // now Text::callsToUpper is 1
   \end{cppcode}
+  \end{exampleblock}
+  \end{overprint}
 \end{frame}


### PR DESCRIPTION
- Add extra slide for static members
- Fix a wrong map::insert
- Convert `()` to `{}` for a `std::thread t1{...}`