### PR TITLE
Fix a tikz positioning directive that points to a non-existing element.

### DIFF
--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -504,7 +504,7 @@
   \end{block}
   \begin{multicols}{2}
     \begin{tikzpicture}[]
-      \classbox[below of=title]{Drawable}{}
+      \classbox{Drawable}{}
       \classbox[below left of=Drawable,node distance=2cm]{Rectangle}{}
       \classbox[right of=Rectangle,node distance=3cm]{Text}{}
       \classbox[below right of=Rectangle,node distance=2cm]{TextBox}{}


### PR DESCRIPTION
I was playing with tikz, and this showed up as error. As far as I can see, the "title" object was removed from that figure.