### PR TITLE
Reorder advanced course

### DIFF
--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -172,11 +172,11 @@
 
 \begin{advanced}
   \section[exp]{Expert \cpp}
+  \input{expert/cpp20spaceship}
   \input{expert/variadictemplate}
   \input{expert/perfectforwarding}
   \input{expert/sfinae}
   \input{expert/cpp20concepts}
-  \input{expert/cpp20spaceship}
   \input{expert/modules}
   \input{expert/coroutines}
 \end{advanced}

--- a/talk/expert/cpp20concepts.tex
+++ b/talk/expert/cpp20concepts.tex
@@ -14,7 +14,7 @@
 
 \begin{frame}[fragile]
   \frametitlecpp[17]{The world before concepts}
-  \begin{block}{\cpp17 work around : SFINAE}
+  \begin{block}{\cpp17 work around: SFINAE}
     \begin{itemize}
     \item Unsuited arguments can be avoided by inserting fake template arguments,
     leading to a substitution failure
@@ -133,7 +133,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \frametitlecpp[20]{Some usages of concepts}
     \begin{block}{Constrained template parameters}
       \begin{itemize}
-        \item a concept can replace \cppinline{typename} in a template parameter lists
+        \item a concept can replace \cppinline{typename} in a template parameter list
       \end{itemize}
     \end{block}
     \begin{exampleblock}{}
@@ -261,7 +261,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
       \end{cppcode*}
     \end{exampleblock}
     \begin{block}{}
-      Remember : use standard concepts first
+      Remember: use standard concepts first
     \end{block}
 \end{frame}
 


### PR DESCRIPTION
For the next iteration, we want slightly increase the emphasis on c++20. Therefore, the operator <=> moves to the beginning of the expert section.
I also fixed minor typographic issues in the concepts section.