### PR TITLE
Dropped useless bigdata member in the functions example

### DIFF
--- a/exercises/functions/Structs.cpp
+++ b/exercises/functions/Structs.cpp
@@ -16,5 +16,4 @@ SlowToCopy::SlowToCopy(const SlowToCopy& other) {
     std::cout << __func__ << ": Please don't copy me. This is slow.\n";
     std::this_thread::sleep_for(std::chrono::seconds(3));
     name = other.name;
-    std::memcpy(bigdata, other.bigdata, sizeof(bigdata));
 }

--- a/exercises/functions/Structs.h
+++ b/exercises/functions/Structs.h
@@ -8,7 +8,6 @@ struct FastToCopy {
 
 struct SlowToCopy {
     std::string name;
-    int bigdata[1000000];
 
     // Functions to create and copy this struct.
     // We go into details on the next days.


### PR DESCRIPTION
It served no purpose (copy was not slow there, only a sleep made it slow) and was discovered (the hard way) to make windows users having very strange segfaults. Simply because it was too large to be on the stack in such context and was screwing memory !
