### PR TITLE
Add a slide on jthreads and simplify goodpractice environment

### DIFF
--- a/talk/basicconcepts/arrayspointers.tex
+++ b/talk/basicconcepts/arrayspointers.tex
@@ -108,9 +108,9 @@ int l = *pak;
 
     free(ai); // release memory
   \end{cppcode}
-  \begin{goodpracticeWithShortcut}{Don't use C's memory management}{C's memory management}
+  \begin{goodpractice}[C's memory management]{Don't use C's memory management}
     Use \cppinline{std::vector} and friends or smart pointers
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]
@@ -130,7 +130,7 @@ int l = *pak;
     int* pi = new int{};
     delete pi; // release scalar memory
   \end{cppcode}
-  \begin{goodpracticeWithShortcut}{Don't use manual memory management}{Manual memory management}
+  \begin{goodpractice}[Manual memory management]{Don't use manual memory management}
     Use \cppinline{std::vector} and friends or smart pointers
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -193,11 +193,11 @@
     \end{cppcode*}
   \end{exampleblock}
   \pause
-  \begin{goodpracticeWithShortcut}{Don't abuse the \texttt{for} syntax}{\texttt{for} syntax}
+  \begin{goodpractice}[\texttt{for} syntax]{Don't abuse the \texttt{for} syntax}
     \begin{itemize}
       \item The \cppinline{for} loop head should fit in 1-3 lines
     \end{itemize}
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/basicconcepts/headersinterfaces.tex
+++ b/talk/basicconcepts/headersinterfaces.tex
@@ -41,12 +41,12 @@
     #endif
   \end{cppcode}
   \pause
-  \begin{goodpracticeWithShortcut}{Use preprocessor only in very restricted cases}{preprocessor}
+  \begin{goodpractice}[preprocessor]{Use preprocessor only in very restricted cases}
     \begin{itemize}
       \item Conditional inclusion of headers
       \item Customization for specific compilers/platforms
     \end{itemize}
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/concurrency/threadsasync.tex
+++ b/talk/concurrency/threadsasync.tex
@@ -1,50 +1,34 @@
 \subsection[thr]{Threads and async}
 
 \begin{frame}[fragile]
-  \frametitle{Basic concurrency \hfill \cpp11/\cpp20}
+  \frametitlecpp[11]{Basic concurrency}
   \begin{block}{Threading}
     \begin{itemize}
     \item \cpp11 added \cppinline{std::thread} in \cppinline{<thread>} header
     \item takes a function as argument of its constructor
     \item must be detached or joined before the main thread terminates
-    \item \cpp20: \cppinline{std::jthread} automatically joins at destruction
     \end{itemize}
   \end{block}
-  \vspace{-1\baselineskip}
-  \begin{overprint}
-    \onslide<1>
-    \begin{exampleblock}{Example code}
-      \begin{cppcode*}{gobble=2}
-        void foo() {...}
-        void bar() {...}
-        int main() {
-          std::thread t1{foo};
-          std::thread t2{bar};
-          for (auto t: {&t1,&t2}) t->join();
-          return 0;
-        }
-      \end{cppcode*}
-    \end{exampleblock}
-    \onslide<2>
-    \begin{exampleblock}{Example with jthread (\cpp20)}
-      \begin{cppcode*}{gobble=2}
-        void foo() {...}
-        void bar() {...}
-        int main() {
-          std::jthread t1{foo};
-          std::jthread t2{bar};
-          return 0;
-        }
-      \end{cppcode*}
-    \end{exampleblock}
-  \end{overprint}
+
+  \begin{exampleblock}{Example code}
+    \begin{cppcode*}{gobble=2}
+      void foo() {...}
+      void bar() {...}
+      int main() {
+        std::thread t1{foo};
+        std::thread t2{bar};
+        for (auto t: {&t1,&t2}) t->join();
+        return 0;
+      }
+    \end{cppcode*}
+  \end{exampleblock}
 \end{frame}
 
 \begin{frame}[fragile]
   \frametitlecpp[11]{The thread constructor}
   \begin{exampleblock}{Can take a function and its arguments}
     \begin{cppcode*}{}
-      void function(int j, double j) {...};
+      void function(int j, double j) {...}
       std::thread t1{function, 1, 2.0};
     \end{cppcode*}
   \end{exampleblock}
@@ -63,6 +47,57 @@
     \end{cppcode*}
   \end{exampleblock}
 \end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[20]{\texttt{std::jthread}}
+  \begin{goodpractice}[jthread vs.\ thread]{Prefer \cppinline{std::jthread} if \cpp20 is available}
+    \begin{itemize}
+    \item In \cppinline{<thread>} header since \cpp20
+    \item Automatically joins on destruction
+    \item Can be stopped from outside
+    \end{itemize}
+  \end{goodpractice}
+
+  \begin{exampleblock}{Example with jthread}
+    \begin{cppcode*}{gobble=2}
+      void foo() {...}
+      void bar() {...}
+      int main() {
+        std::jthread t1{foo};
+        std::jthread t2{bar}; t2.request_stop();
+        // No join required
+        return 0;
+      }
+    \end{cppcode*}
+  \end{exampleblock}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[20]{Using jthread's stop\_token}
+  \begin{block}{}
+    \begin{itemize}
+      \item Like \cppinline{std::thread}, \cppinline{jthread} can take a function or functors/lambdas and their arguments
+      \item New: Can take functions that handle \cppinline{stop_token}s
+    \end{itemize}
+  \end{block}
+  \begin{exampleblock}{stop\_token in a function}
+    \begin{cppcode*}{}
+    void function(std::stop_token st, int j) {
+      while (!st.stop_requested()) {
+        // ...
+    }}
+    std::jthread t1{function, 1};
+    t1.request_stop();
+    \end{cppcode*}
+  \end{exampleblock}
+  \begin{exampleblock}{A lambda with a stop\_token}
+    \begin{cppcode*}{}
+    std::jthread t1{
+      [](std::stop_token st, int i){ ... }, 1};
+    \end{cppcode*}
+  \end{exampleblock}
+\end{frame}
+
 
 \begin{frame}[fragile]
   \frametitlecpp[11]{Basic asynchronicity}

--- a/talk/morelanguage/raii.tex
+++ b/talk/morelanguage/raii.tex
@@ -121,9 +121,9 @@
       }
     \end{cppcode*}
   \end{exampleblock}
-  \begin{goodpracticeWithShortcut}{Use \texttt{std::fstream} for file handling}{Use \texttt{std::fstream}}
+  \begin{goodpractice}[Use \texttt{std::fstream}]{Use \texttt{std::fstream} for file handling}
      The standard library provides \cppinline{std::fstream} to handle files, use it!
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]
@@ -428,9 +428,9 @@ print();
 
 \begin{frame}[fragile]
     \frametitlecpp[11]{Rule of zero}
-    \begin{goodpracticeWithShortcut}{Single responsibility principle (SRP)}{Single responsibility principle}
+    \begin{goodpractice}[Single responsibility principle]{Single responsibility principle (SRP)}
         Every class should have only one responsibility.
-    \end{goodpracticeWithShortcut}
+    \end{goodpractice}
     \begin{goodpractice}{Rule of zero}
         \begin{itemize}
             \item If your class has any special member functions (except ctor.)

--- a/talk/morelanguage/random.tex
+++ b/talk/morelanguage/random.tex
@@ -116,7 +116,7 @@
       \item E.g.: \cppinline{rand() % 10} yields biased numbers and is wrong!
     \end{itemize}
   \end{alertblock}
-  \begin{goodpracticeWithShortcut}{Strongly avoid the C random library}{C random library}
+  \begin{goodpractice}[C random library]{Strongly avoid the C random library}
     Use the \cpp11 facilities from the \cppinline{<random>} header
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}

--- a/talk/morelanguage/stl.tex
+++ b/talk/morelanguage/stl.tex
@@ -284,12 +284,12 @@
     \end{cppcode*}
   \end{exampleblock}
   \pause
-  \begin{goodpracticeWithShortcut}{Use STL algorithms with lambdas}{STL and lambdas}
+  \begin{goodpractice}[STL and lambdas]{Use STL algorithms with lambdas}
     \begin{itemize}
       \item Prefer lambdas over functors when using the STL
       \item Avoid binders like \cppinline{std::bind2nd}, \cppinline{std::ptr_fun}, etc.
     \end{itemize}
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -536,12 +536,12 @@
     \item And for rare special cases
     \end{itemize}
   \end{goodpractice}
-  \begin{goodpracticeWithShortcut}{Absolutely avoid diamond-shaped inheritance}{NO diamond inheritance}
+  \begin{goodpractice}[NO diamond inheritance]{Absolutely avoid diamond-shaped inheritance}
     \begin{itemize}
     \item This is a sign that your architecture is not correct
     \item In case you are tempted, think twice and change your mind
     \end{itemize}
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/objectorientation/allocations.tex
+++ b/talk/objectorientation/allocations.tex
@@ -102,9 +102,9 @@
       MyFirstClass *a = new MyFirstClass{3};
     } // memory leak !!!
   \end{cppcode}
-  \begin{goodpracticeWithShortcut}{Prefer smart pointers over new/delete}{Prefer smart pointer}
+  \begin{goodpractice}[Prefer smart pointer]{Prefer smart pointers over new/delete}
     Prefer smart pointers to manage objects (discussed later)
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]
@@ -125,7 +125,7 @@
       delete[] a; // destructor called 10 times
     }
   \end{cppcode}
-  \begin{goodpracticeWithShortcut}{Prefer containers over new-ed arrays}{Prefer containers}
+  \begin{goodpractice}[Prefer containers]{Prefer containers over new-ed arrays}
     Prefer containers to manage collections of objects (discussed later)
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -99,9 +99,9 @@
     };
   \end{cppcode}
   \pause
-  \begin{goodpracticeWithShortcut}{The rule of 3/5 (\cpp98/11) - \href{https://en.cppreference.com/w/cpp/language/rule_of_three}{cppreference}}{Rule of 3/5}
+  \begin{goodpractice}[Rule of 3/5]{The rule of 3/5 (\cpp98/11) - \href{https://en.cppreference.com/w/cpp/language/rule_of_three}{cppreference}}
     if a class needs a custom destructor, a copy/move constructor or a copy/move assignment operator, it should have all three/five.
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -140,9 +140,11 @@
 {%
   \end{beamerboxesrounded}
 }
-\newenvironment{goodpractice}[1]
+\newenvironment{goodpractice}[2][]
 {%
-  \begin{goodpracticeWithShortcut}{#1}{#1}
+  \ifthenelse{\equal{#1}{}}%
+    { \begin{goodpracticeWithShortcut}{#2}{#2} }
+    { \begin{goodpracticeWithShortcut}{#2}{#1} }
 }%
 {%
   \end{goodpracticeWithShortcut}


### PR DESCRIPTION
Extend the discussion of jthread and stop_token as suggested in #272.

As a drive-by improvement, I refactored the goodpractice environment to take optional arguments. Now, only a single command with an optional argument is necessary to pass a shortened title for the index of good practices:
```diff
  \end{cppcode}
-  \begin{goodpracticeWithShortcut}{Don't use C's memory management}{C's memory management}
+  \begin{goodpractice}[C's memory management]{Don't use C's memory management}
    Use \cppinline{std::vector} and friends or smart pointers
-  \end{goodpracticeWithShortcut}
+  \end{goodpractice}
\end{frame}
```

This stays the same:
```latex
\begin{goodpractice}{Memory management}
```

Fix #272 