### PR TITLE
Implement comments from #428

### DIFF
--- a/talk/basicconcepts/headersinterfaces.tex
+++ b/talk/basicconcepts/headersinterfaces.tex
@@ -73,3 +73,23 @@
     \end{cppcode*}
   \end{block}
 \end{frame}
+
+\begin{frame}[fragile]
+  \frametitlecpp[98]{Header / source separation}
+  \begin{goodpractice}[Header / source]{Headers and source files}
+    \begin{itemize}
+      \item Headers should contain declarations of functions / classes
+        \begin{itemize}
+          \item Only create them if interface is used somewhere else
+        \end{itemize}
+      \item Might be included/compiled many times
+      \item Good to keep them short
+      \item Minimise \cppinline{#include} statements
+      \item Put long code in implementation files. Exceptions:
+        \begin{itemize}
+          \item Short functions
+          \item Templates and constexpr functions
+        \end{itemize}
+    \end{itemize}
+  \end{goodpractice}
+\end{frame}

--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -1,6 +1,45 @@
 \subsection[advOO]{Advanced OO}
 
 \begin{frame}[fragile]
+  \frametitlecpp[98]{\texttt{this} keyword}
+  \begin{block}{How to know an object's address?}
+    \begin{itemize}
+    \item Sometimes we need the address of the current object
+    \item Or we need to pass our address / a reference to a different entity
+      (for example to implement operators, see later)
+    \item All class methods can use the keyword \cppinline{this}
+      \begin{itemize}
+        \item It returns the address of the current object
+        \item Its type is \cppinline{T*} in the methods of a class {\ttfamily T}
+      \end{itemize}
+    \end{itemize}
+  \end{block}
+  \begin{minipage}{0.7\textwidth}
+  \begin{cppcode}
+    struct S {
+      int a,b;
+      // these two are the same:
+      int getB() { return b; }       // 5
+      int getB() { return this->b; } // 5
+      void testAddress() {
+        S* addr = this; // 0x3000
+      }
+    } s{2,5};
+  \end{cppcode}
+  \end{minipage}%
+  \hfil%
+  \begin{minipage}{0.3\textwidth}
+      \begin{tikzpicture}
+        \memorystack[size x=2cm,word size=1,block size=4,nb blocks=4]
+        \memorypush{a = 2}
+        \memorypush{b = 5}
+        \memorystruct{1}{2}{\tiny s}
+        \draw[-Triangle,thick] (\stacksizex-1*\stacksizey,-1*\stacksizey) node[left] {\footnotesize \cppinline{this} pointer} -- (\stacksizex,-0.1*\stacksizey);
+      \end{tikzpicture}
+    \end{minipage}
+\end{frame}
+
+\begin{frame}[fragile]
   \frametitlecpp[98]{Polymorphism}
   \begin{block}{the concept}
     \begin{itemize}

--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -571,15 +571,18 @@
   \frametitlecpp[98]{Multiple inheritance advice}
   \begin{goodpractice}{Avoid multiple inheritance}
     \begin{itemize}
-    \item Except for inheriting from interfaces
-    \item And for rare special cases
+      \item Except for inheriting from interfaces (=no data members)
+      \item And for rare special cases
     \end{itemize}
-  \end{goodpractice}
-  \begin{goodpractice}[NO diamond inheritance]{Absolutely avoid diamond-shaped inheritance}
-    \begin{itemize}
-    \item This is a sign that your architecture is not correct
-    \item In case you are tempted, think twice and change your mind
-    \end{itemize}
+
+    \hspace*{0.05\textwidth}\begin{minipage}{0.9\textwidth}
+      \begin{alertblock}{Absolutely avoid diamond-shape inheritance}
+        \begin{itemize}
+        \item This is a sign that your architecture is not correct
+        \item In case you are tempted, think twice and change your mind
+        \end{itemize}
+      \end{alertblock}
+    \end{minipage}
   \end{goodpractice}
 \end{frame}
 

--- a/talk/objectorientation/inheritance.tex
+++ b/talk/objectorientation/inheritance.tex
@@ -42,7 +42,6 @@
         \memorypush{a = 2}
         \memorypush{b = 5}
         \memorystruct{1}{2}{\tiny myobj2}
-        \draw[-Triangle,thick] (\stacksizex-1*\stacksizey,-1*\stacksizey) node[left] {\footnotesize \cppinline{this} pointer} -- (\stacksizex,-0.1*\stacksizey);
       \end{tikzpicture}
     \end{overprint}
     \vfill \null

--- a/talk/objectorientation/inheritance.tex
+++ b/talk/objectorientation/inheritance.tex
@@ -57,10 +57,9 @@
     \end{description}
     \begin{itemize}
        \item The default for \texttt{class} is \cppinline{private}
-       \item A \cppinline{struct} is just a class that defaults to \cppinline{public} access
+       \item The default for \texttt{struct} is \cppinline{public}
     \end{itemize}
   \end{block}
-  \pause
   \begin{multicols}{2}
     \begin{cppcode*}{gobble=2}
       class MyFirstClass {
@@ -207,7 +206,7 @@
       \draw[very thick,-Triangle] (MyThirdClass)--(MySecondClass) node[midway,right] {public};
     \end{tikzpicture}
     \columnbreak
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{gobble=2,highlightlines=14}
       void funcSecond() {
         int a = priv;   // Error
         int b = prot;   // OK
@@ -249,7 +248,7 @@
       \draw[very thick,-Triangle] (MyThirdClass)--(MySecondClass) node[midway,right] {public};
     \end{tikzpicture}
     \columnbreak
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{gobble=2,highlightlines=8-9}
       void funcSecond() {
         int a = priv;   // Error
         int b = prot;   // OK

--- a/talk/objectorientation/objectsclasses.tex
+++ b/talk/objectorientation/objectsclasses.tex
@@ -117,40 +117,18 @@
     \item some functions (templates, \cppinline{constexpr}) must be in the header
     \end{itemize}
   \end{goodpractice}
-  \begin{cppcode}
+  \begin{block}{}
+    \begin{cppcode}
+    #include "MyFirstClass.hpp"
+
     void MyFirstClass::squareA() {
       a *= a;
     }
-
     int MyFirstClass::sum(int b) {
       return a + b;
     }
-  \end{cppcode}
-\end{frame}
-
-\begin{frame}[fragile]
-  \frametitlecpp[98]{\texttt{this} keyword}
-  \begin{block}{How to know an object's address?}
-    \begin{itemize}
-    \item Sometimes we need to pass a reference to ourself to a different entity
-    \item For example to implement operators, see later
-    \item All class methods can use the keyword \cppinline{this}
-      \begin{itemize}
-        \item It returns the address of the current object
-        \item Its type is \cppinline{T*} in the methods of a class {\ttfamily T}
-      \end{itemize}
-    \end{itemize}
+    \end{cppcode}
   \end{block}
-  \begin{cppcode}
-    void freeFunc(S & s);
-    struct S {
-      void memberFunc() { // Implicit S* parameter
-        freeFunc(*this);  // Pass a reference to ourself
-      }
-    };
-    S s;
-    s.memberFunc();       // Passes &s implicitly
-  \end{cppcode}
 \end{frame}
 
 \begin{frame}[fragile]

--- a/talk/objectorientation/operators.tex
+++ b/talk/objectorientation/operators.tex
@@ -17,28 +17,36 @@
   \end{cppcode}
 \end{frame}
 
-\begin{frame}
+\begin{frame}[fragile]
   \frametitlecpp[98]{Operator overloading}
   \begin{block}{Defining operators for a class}
     \begin{itemize}
     \item implemented as a regular method
       \begin{itemize}
-      \item either inside the class, as a member function
+      \item \small either inside the class, as a member function
       \item or outside the class (not all)
       \end{itemize}
-    \item with a special name (replace @ by anything)
-      \begin{tabular}{llll}
-        Expression & As member & As non-member \\
-        \hline
-        @a & (a).operator@() & operator@(a) \\
-        a@b & (a).operator@(b) & operator@(a,b) \\
-        a=b & (a).operator=(b) & cannot be non-member \\
-        a(b...) & (a).operator()(b...) & cannot be non-member \\
-        a[b] & (a).operator[](b) & cannot be non-member \\
-        a-\textgreater & (a).operator-\textgreater() & cannot be non-member \\
-        a@ & (a).operator@(0) & operator@(a,0) \\
-      \end{tabular}
+    \item with a special name (replace @ by operators from below)\small
     \end{itemize}
+    \begin{tabular}{llll}
+      Expression & As member & As non-member \\
+      \hline
+      @a & (a).operator@() & operator@(a) \\
+      a@b & (a).operator@(b) & operator@(a,b) \\
+      a=b & (a).operator=(b) & cannot be non-member \\
+      a(b...) & (a).operator()(b...) & cannot be non-member \\
+      a[b] & (a).operator[](b) & cannot be non-member \\
+      a-\textgreater & (a).operator-\textgreater() & cannot be non-member \\
+      a@ & (a).operator@(0) & operator@(a,0) \\
+      \hline
+    \end{tabular}
+
+    \small
+    \begin{cppcode*}{linenos=false}
+      possible operators: + - * / % ^ & | ~ ! = < >
+          += -= *= /= %= ^= &= |= << >> >>= <<=
+          == != <= >= <=> && || ++ -- , ->* -> () []
+    \end{cppcode*}
   \end{block}
 \end{frame}
 

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -401,7 +401,7 @@
   \memorystackset{
     size y/.get=\stacksizey
   }
-  \draw[snake=brace,thick] (-2pt,#1*\stacksizey-\stacksizey) -- (-2pt,#2*\stacksizey)
+  \draw[snake=brace,thick] (-2pt,#1*\stacksizey-\stacksizey+2pt) -- (-2pt,#2*\stacksizey-2pt)
     node [midway, above, sloped] {#3};
 }
 


### PR DESCRIPTION
This is the implementation of many remarks / suggestions made in #428, such as:
- Better explain header/source separation
- Add some code highlights or drawings
- ~~Discuss object slicing~~
- Add possible operator symbols for overloading
- Move `this` slide to a later stage of the OO chapter (and change the confusing code example)

I decided to disregard many comments from #428, because there was no reasonable way to change the slides. These comments referred rather to what we say or questions that the students asked. All the things I did implement are marked with tick boxes, and the things I left out have empty boxes in #428. I don't see a way to do better, so I propose to close the issue after this PR.

Resolves #428