### PR TITLE
Add an exercise on UBSan

### DIFF
--- a/exercises/ExerciseSchedule_AdvancedCourse.md
+++ b/exercises/ExerciseSchedule_AdvancedCourse.md
@@ -36,6 +36,8 @@ People should replay them and discover the tools by themselves.
 
 ### (optional) Address sanitizer (directory: [`asan`](asan), [cheatSheet](ExercisesCheatSheet.md#address-sanitizer-directory-asan))
 
+### (optional) Undefined behaviour sanitizer (directory: [`ubsan`](ubsan)
+
 
 Day 3
 -----

--- a/exercises/ubsan/README.md
+++ b/exercises/ubsan/README.md
@@ -20,4 +20,3 @@ it Continuous Integration.
         program and catch the bugs, or continue with the next exercise.
 
 - Try to understand what's wrong. The solution contains a few comments what kind of bugs are hidden in the program.
-

--- a/exercises/ubsan/README.md
+++ b/exercises/ubsan/README.md
@@ -1,0 +1,23 @@
+# Undefined Behaviour Sanitizer
+
+This directory contains a program that's full of evil bugs. Many of those would cause compiler warnings,
+but the problems can easily be obscured by making the code slightly more complicated, e.g. by passing
+pointers or indices through functions or similar.
+
+UBSan is a run-time tool, so it can catch these bugs even if the compilers don't emit warnings.
+This should illustrate why every larger project should have a UBSan and a ASan build as part of
+it Continuous Integration.
+
+## Instructions
+
+- Compile and run this program using a compiler invocation like
+  `<compiler> -g -std=c++17 -o undefinedBehaviour undefinedBehaviour.cpp`
+
+- You might see warnings depending on the compiler, but on most platforms the program runs without observable issues.
+
+- Recompile with "-fsanitize=undefined", and observe that almost every second line contains a serious bug.
+  NOTE: If this fails, your compiler does not support UBSan (yet). In this case, you can try to read the
+        program and catch the bugs, or continue with the next exercise.
+
+- Try to understand what's wrong. The solution contains a few comments what kind of bugs are hidden in the program.
+

--- a/exercises/ubsan/solution/undefinedBehaviour.cpp
+++ b/exercises/ubsan/solution/undefinedBehaviour.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <limits>
+
+// You don't need to change any code in these structs:
+struct Base {
+  virtual void print() = 0;
+  virtual ~Base() {}
+};
+struct Derived1 : public Base {
+  void print() override {
+    std::cout << "Derived1::print()\n";
+  }
+};
+struct Derived2 : public Base {
+  void print() override {
+    std::cout << "Derived2::print()\n";
+  }
+};
+
+
+/**
+ * ***************
+ *  Instructions:
+ * ***************
+ *
+ * Compile and run this program using a compiler invocation like
+ * <compiler> -g -std=c++17 -o undefinedBehaviour undefinedBehaviour.cpp
+ *
+ * You might see warnings depending on the compiler, but on most platforms the program runs without observable issues.
+ * Smart compilers will warn with most of these bugs, but the compilers can easily be deceived by hiding a nullptr in
+ * a variable, or passing it as a function argument or similar.
+ *
+ * Since UBSan does runtime checks, it will catch these errors even if they are obscured.
+ * Recompile with "-fsanitize=undefined", and observe that almost every second line contains a serious bug.
+ * Try to understand what's wrong.
+ */
+
+int runTests() {
+  int arr[] = {1, 2, 3, 4};
+  std::cout << "arr[4]=" << arr[4] << "\n";             // Array overrun
+
+  unsigned short s = 1;
+  std::cout << "s << 33=" << (s << 33) << "\n";         // We cannot shift a type with 32 bits by 33 bits.
+
+  int i = std::numeric_limits<int>::max();
+  std::cout << "i + 1 =" << i + 1 << "\n";              // Adding 1 to max int overflows to min int
+
+  Derived1 d1;
+  Base & base = d1;
+  auto & d2 = static_cast<Derived2&>(base);             // Casting an original d1 to d2 is wrong
+  d2.print();                                           // Calling a function on a wrongly-cast object is wrong
+
+  Derived2 * d2ptr = nullptr;
+  Derived2 & nullref = static_cast<Derived2&>(*d2ptr);  // Cannot bind references to a wrong address
+}                                                       // Forgot to return a value
+
+int main() {
+  const auto result = runTests();
+  return result;
+}

--- a/exercises/ubsan/undefinedBehaviour.cpp
+++ b/exercises/ubsan/undefinedBehaviour.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <limits>
+
+// You don't need to change any code in these structs:
+struct Base {
+  virtual void print() = 0;
+  virtual ~Base() {}
+};
+struct Derived1 : public Base {
+  void print() override {
+    std::cout << "Derived1::print()\n";
+  }
+};
+struct Derived2 : public Base {
+  void print() override {
+    std::cout << "Derived2::print()\n";
+  }
+};
+
+
+/**
+ * ***************
+ *  Instructions:
+ * ***************
+ *
+ * Compile and run this program using a compiler invocation like
+ * <compiler> -g -std=c++17 -o undefinedBehaviour undefinedBehaviour.cpp
+ *
+ * You might see warnings depending on the compiler, but on most platforms the program runs without observable issues.
+ * Smart compilers will warn with most of these bugs, but the compilers can easily be deceived by hiding a nullptr in
+ * a variable, or passing it as a function argument or similar.
+ *
+ * Since UBSan does runtime checks, it will catch these errors even if they are obscured.
+ * Recompile with "-fsanitize=undefined", and observe that almost every second line contains a serious bug.
+ * Try to understand what's wrong.
+ */
+
+int runTests() {
+  int arr[] = {1, 2, 3, 4};
+  std::cout << "arr[4]=" << arr[4] << "\n";
+
+  unsigned short s = 1;
+  std::cout << "s << 33=" << (s << 33) << "\n";
+
+  int i = std::numeric_limits<int>::max();
+  std::cout << "i + 1 =" << i + 1 << "\n";
+
+  Derived1 d1;
+  Base & base = d1;
+  auto & d2 = static_cast<Derived2&>(base);
+  d2.print();
+
+  Derived2 * d2ptr = nullptr;
+  Derived2 & nullref = static_cast<Derived2&>(*d2ptr);
+}
+
+int main() {
+  const auto result = runTests();
+  return result;
+}

--- a/talk/tools/sanitizers.tex
+++ b/talk/tools/sanitizers.tex
@@ -260,3 +260,16 @@ up.cpp:3:5: runtime error: signed integer overflow:
     \url{https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html}
   \end{block}
 \end{frame}
+
+\begin{frame}[fragile]
+  \frametitle{Undefined Behaviour Sanitizer (UBSan)}
+  \begin{exercise}{Finding evil run-time bugs}
+    \begin{itemize}
+      \item Go to \texttt{exercises/ubsan}
+      \item Compile and run the program following the instructions in README or in the program
+      \item The program should run without observable issues
+      \item Recompile with UBSan and see that almost every second line contains evil bugs
+    \end{itemize}
+  \end{exercise}
+
+\end{frame}


### PR DESCRIPTION
Add a bug-ridden program that runs mostly without observable issues, but is full of undefined behaviour.

Using UBSan, all of these issues get revealed at run time.

Fix #243