### PR TITLE
Make functions exercise less confusing.

### DIFF
--- a/exercises/functions/README.md
+++ b/exercises/functions/README.md
@@ -14,7 +14,7 @@ They are exactly what their name says, so let's try to avoid copying the latter.
 
 ## Step 2
 
-Using `printFiveCharacters()` as an example, write a function that prints the first five characters of `SlowToCopy`. Call it in `main()`.
+Using `printName()` as an example, write a function that prints the name of `SlowToCopy`. Call it in `main()`.
 
 ## Step 3
 
@@ -22,6 +22,6 @@ Try passing by copy and passing by reference, see the difference.
 
 ## Step 4
 
-When passing by reference, ensure that your `printFiveCharacters` cannot inadvertently modify the original object.
-To test its const correctness, try adding something like `argument.name[0] = 'a';` to your print function.
+When passing by reference, ensure that your `printName` cannot inadvertently modify the original object.
+To test its const correctness, try adding something like `argument.name = "a";` to your print function.
 Try both with and without const attributes in your print function's signature.

--- a/exercises/functions/Structs.cpp
+++ b/exercises/functions/Structs.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 
 /// Construct a new instance of SlowToCopy.
-SlowToCopy::SlowToCopy() : name("Large type") {}
+SlowToCopy::SlowToCopy() : name("SlowToCopy") {}
 
 /// Construct a new instance of SlowToCopy.
 SlowToCopy::SlowToCopy(const std::string& name) : name(name) {}

--- a/exercises/functions/functions.cpp
+++ b/exercises/functions/functions.cpp
@@ -4,30 +4,29 @@
  *    FastToCopy
  *    SlowToCopy
  *    They are exactly what their name says, so let's try to avoid copying the latter.
- * 2. Using "printFiveCharacters()" as an example, write a function that prints the first five characters of "SlowToCopy".
+ * 2. Using "printName()" as an example, write a function that prints the name of "SlowToCopy".
  *    Call it in main().
  * 3. Try passing by copy and passing by reference, see the difference.
- * 4. When passing by reference, ensure that your "printFiveCharacters" cannot inadvertently modify the original object.
+ * 4. When passing by reference, ensure that your "printName" cannot inadvertently modify the original object.
  *    To test its const correctness, try adding something like
- *      argument.name[0] = 'a';
+ *      argument.name = "other name";
  *    to your print function.
  *    Try both with and without const attributes in your print function's signature.
- * 5. Bonus: Can you fix "printFiveCharacters" to actually only print the first five characters and not the entire string?
  */
 
 #include "Structs.h" // The data structs we will work with
 
 #include <iostream> // For printing
 
-void printFiveCharacters(FastToCopy argument) {
+void printName(FastToCopy argument) {
     std::cout << argument.name << '\n';
 }
 
 int main() {
-    FastToCopy fast = {"abcdefghijkl"};
-    printFiveCharacters(fast);
+    FastToCopy fast = {"Fast"};
+    printName(fast);
 
-    SlowToCopy slow = {"ABCDEFGHIJKL"};
+    SlowToCopy slow = {"Slow"};
     // print it here
 
     return 0;

--- a/exercises/functions/solution/functions.sol.cpp
+++ b/exercises/functions/solution/functions.sol.cpp
@@ -4,12 +4,12 @@
  *    FastToCopy
  *    SlowToCopy
  *    They are exactly what their name says, so let's try to avoid copying the latter.
- * 2. Using "printFiveCharacters()" as an example, write a function that prints the first five characters of "SlowToCopy".
+ * 2. Using "printName()" as an example, write a function that prints the name of "SlowToCopy".
  *    Call it in main().
  * 3. Try passing by copy and passing by reference, see the difference.
- * 4. When passing by reference, ensure that your "printFiveCharacters" cannot inadvertently modify the original object.
+ * 4. When passing by reference, ensure that your "printName" cannot inadvertently modify the original object.
  *    To test its const correctness, try adding something like
- *      argument.name[0] = 'a';
+ *      argument.name = "other name";
  *    to your print function.
  *    Try both with and without const attributes in your print function's signature.
  */
@@ -18,37 +18,33 @@
 
 #include <iostream> // For printing
 
-void printFiveCharacters(FastToCopy argument) {
-    for (int i = 0; i < 5; i++)
-        std::cout << argument.name[i];
-    std::cout << '\n';
-
-    // alternative 1: std::cout << argument.name.substr(0, 5) << '\n';
-    // alternative 2: std::cout << std::string_view{argument.name.data(), 5} << '\n';
-    // alternative C: std::printf("%.5s\n", argument.name.c_str());
-    // alternative C++23: std::print("{:.5}\n", argument);
-}
-
-void printFiveCharacters(const SlowToCopy & argument) {
-    //argument.data[0] = '\n' ; // EXPECTED COMPILATION ERROR
+void printName(FastToCopy argument) {
     std::cout << argument.name << '\n';
 }
 
-void printFiveCharactersWithCopy(SlowToCopy argument) {
+void inefficientPrintName(SlowToCopy argument) {
     std::cout << argument.name << '\n';
-    // We can actually modify the argument if we want, since it's a copy:
-    argument.name[0] = 'a';
+
+    // We can change the argument's name because it's a copy:
+    argument.name = "New name";
+}
+
+void printName(const SlowToCopy & argument) {
+    std::cout << argument.name << '\n';
+
+    // We are unable to change name, as we should:
+    //argument.name = '\n';
 }
 
 int main() {
-    FastToCopy fast = {"abcdefghijkl"};
-    printFiveCharacters(fast);
+    FastToCopy fast = {"Fast"};
+    printName(fast);
 
-    SlowToCopy slow = {"ABCDEFGHIJKL"};
-    printFiveCharacters(slow);
+    SlowToCopy slow = {"Slow"};
+    printName(slow);
 
     std::cout << "Now printing with copy:\n";
-    printFiveCharactersWithCopy(slow);
+    inefficientPrintName(slow);
 
     return 0;
 }


### PR DESCRIPTION
After the functions exercise has been modernised (no arrays, std::string instead), there is no need to print "fiveCharacters". The exercise is about pass by copy vs pass by reference and overloading, so the confusing instructions have been removed.

Fix #426