### PR TITLE
Fix a crash in constplay exercise

### DIFF
--- a/exercises/constness/constplay.cpp
+++ b/exercises/constness/constplay.cpp
@@ -63,8 +63,8 @@ int main() {
 
     // try constant arguments of functions with pointers
     {
-      int *p = 0;
-      const int *r = 0;
+      int *p = &a;
+      const int *r = &b;
       write(p);
       write(r);
       read(p);

--- a/talk/tools/debugging.tex
+++ b/talk/tools/debugging.tex
@@ -76,6 +76,7 @@
       \item windows for variables, breakpoints, call stack, active threads, watch variables in-code, disassembly, run to cursor ...
     \end{itemize}
     \begin{description}
+      \item[Native gdb] Try ``tui enable'' for a simple built-in UI
       \item[\href{https://code.visualstudio.com/docs/cpp/cpp-debug}{\beamergotobutton{VSCode}}]
         Built-in support for gdb
       \item[\href{https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb}{\beamergotobutton{CodeLLDB}}]


### PR DESCRIPTION
Although the exercise is mostly about battling with the compiler, once people finish this work, they will encounter a crash when running the program.
Here, we init the two pointers to &a and &b to create a runnable program.

@sponce Were the students supposed to fix the crash as well, or should we limit it to "just" compile it and then it should run without errors?