### PR TITLE
Make explicit statement that C++ compiled "to native machine code"

### DIFF
--- a/talk/introduction/goals.tex
+++ b/talk/introduction/goals.tex
@@ -13,7 +13,7 @@
   \pause
   \begin{block}{Fast}
     \begin{itemize}
-    \item compiled (unlike Java, C\#, Python, ...)
+    \item compiled to native machine code (unlike Java, C\#, Python, ...)
     \item allows to go close to hardware when needed
     \end{itemize}
   \end{block}

--- a/talk/introduction/goals.tex
+++ b/talk/introduction/goals.tex
@@ -13,7 +13,10 @@
   \pause
   \begin{block}{Fast}
     \begin{itemize}
-    \item compiled to native machine code (unlike Java, C\#, Python, ...)
+    \item compiled to native machine code
+      \begin{itemize}
+      \item unlike Java, C\#, Python, ...
+      \end{itemize}
     \item allows to go close to hardware when needed
     \end{itemize}
   \end{block}


### PR DESCRIPTION
All main implementation of the languages in the example (Java, C# and Python) are actually compiled to bytecode. IMHO it's better to clearly add explicit statement that C++ is compiled "to native machine code" unlike this languages to avoid ambiguity.
