### PR TITLE
[Advanced] Add a marker on advanced slides.

### DIFF
--- a/exercises/ExerciseSchedule_AdvancedCourse.md
+++ b/exercises/ExerciseSchedule_AdvancedCourse.md
@@ -5,7 +5,7 @@ HEP C++ Advanced Course's exercise schedule
 - Solutions and hints can be found in the ExercisesCheatSheet.md file located in the same directory.
 - Each exercise is in its own directory and referred to in the following by the name of the directory
 
-There are far too many exercies on each day. They are given in order in which they should be done.
+There are far too many exercises on each day. They are given in order in which they should be done.
 
 Day 1
 -----

--- a/talk/C++Course.tex
+++ b/talk/C++Course.tex
@@ -28,8 +28,10 @@
   % advanced slides have a different structure color
   \specialcomment{advanced}{
     \setbeamercolor{structure}{fg=beamer@blendedblue!40!violet}
+    \isAdvancedSlidetrue
   }{
     \setbeamercolor{structure}{fg=beamer@blendedblue}
+    \isAdvancedSlidefalse
   }
 \fi
 

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -216,7 +216,7 @@
   \frametitlecpp[11]{Constructor inheritance}
   \begin{block}{Idea}
     \begin{itemize}
-    \item avoid having to re-declare parent's constructors
+    \item avoid having to redeclare parent's constructors
     \item by stating that we inherit all parent constructors
     \item derived class can add more constructors
     \end{itemize}

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -188,9 +188,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % frametitle with C++ version %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Switch designs for advanced and essentials course:
+\newif\ifisAdvancedSlide\isAdvancedSlidefalse
 % Use as \frametitlecpp[14]{Title}
 \newcommand\frametitlecpp[2][98]{
-  \frametitle{#2 \hfill \cpp#1}
+  \ifisAdvancedSlide
+    \frametitle{#2 \hfill \cpp#1 \small Adv}
+  \else
+    \frametitle{#2 \hfill \cpp#1}
+  \fi
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
It can be difficult to tell the difference between the advanced and essentials slides based on the colour.
Here, we add a little "Adv" in the top right corner.

It currently looks like this (later customisation can be done in `setup.tex` for the command `\frametitlecpp`.
<img width="651" alt="image" src="https://github.com/user-attachments/assets/5e499c43-28da-463b-a20b-77499499e421">
