### PR TITLE
Fix typo extend -> extent in span section

### DIFF
--- a/talk/morelanguage/morestl.tex
+++ b/talk/morelanguage/morestl.tex
@@ -45,7 +45,7 @@
       \begin{itemize}
       \item and thus to be passed by value
       \end{itemize}
-    \item \cppinline{span} can also have a \texttt{static extend}
+    \item \cppinline{span} can also have a \texttt{static extent}
       \begin{itemize}
       \item meaning the size is determined at compile time
       \item and thus only a pointer is stored by \cppinline{span}


### PR DESCRIPTION
Hi,

I spotted a typo in the `span` section: exten**d** should be changed to exten**t**.

Cheers.