### PR TITLE
Install extra texlive packages before building the slides

### DIFF
--- a/.github/workflows/build-slides.yml
+++ b/.github/workflows/build-slides.yml
@@ -20,6 +20,12 @@ jobs:
       matrix:
         version: [ essentials, full ]
     steps:
+      # https://github.com/gpoore/minted/issues/401
+      - name: Reinstall minted
+        run: |
+          sudo apt-get install texlive-latex-extra python3-pygments
+          #tlmgr uninstall minted
+          #tlmgr install minted
       - name: Set up Git repository
         uses: actions/checkout@v4
       - name: Compile essentials


### PR DESCRIPTION
Texlive packages seem to have disappeared from the standard image, so try installing them here.

**Edit**:
This actually goes back to a packaging error, see
https://github.com/gpoore/minted/issues/401

Will try next to reinstall using tlmgr.