### PR TITLE
Used autogobble everywhere in minted by default

### DIFF
--- a/talk/basicconcepts/classenum.tex
+++ b/talk/basicconcepts/classenum.tex
@@ -6,7 +6,7 @@
     \center ``members'' grouped together under one name
   \end{mdframed}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct Individual {
         unsigned char age;
         float weight;
@@ -21,7 +21,7 @@
       };
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=14}
+    \begin{cppcode*}{firstnumber=14}
       Individual *ptr = &student;
       ptr->age = 25;
       // same as: (*ptr).age = 25;
@@ -56,7 +56,7 @@
     \center ``members'' packed together at same memory location
   \end{mdframed}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       union Duration {
         int seconds;
         short hours;
@@ -104,7 +104,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       enum VehicleType {
 
         BIKE,  // 0
@@ -114,7 +114,7 @@
       VehicleType t = CAR;
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=8}
+    \begin{cppcode*}{firstnumber=8}
       enum VehicleType
         : int { // C++11
         BIKE = 3,
@@ -158,7 +158,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{More sensible example}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       enum class ShapeType {
         Circle,
         Rectangle
@@ -171,7 +171,7 @@
     \end{cppcode*}
     \columnbreak
     \pause
-    \begin{cppcode*}{gobble=2,firstnumber=10}
+    \begin{cppcode*}{firstnumber=10}
       struct Shape {
         ShapeType type;
         union {
@@ -183,7 +183,7 @@
   \end{multicols}
   \pause
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2,firstnumber=17}
+    \begin{cppcode*}{firstnumber=17}
       Shape s;
       s.type =
         ShapeType::Circle;
@@ -191,7 +191,7 @@
 
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=20}
+    \begin{cppcode*}{firstnumber=20}
       Shape t;
       t.type =
         Shapetype::Rectangle;
@@ -205,14 +205,14 @@
   \frametitle{typedef and using \hfill \cpp98 / \cpp11}
   Used to create type aliases
   \begin{alertblock}{\cpp98}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       typedef std::uint64_t myint;
       myint count = 17;
       typedef float position[3];
     \end{cppcode*}
   \end{alertblock}
   \begin{exampleblock}{\cpp11}
-    \begin{cppcode*}{gobble=2,firstnumber=4}
+    \begin{cppcode*}{firstnumber=4}
       using myint = std::uint64_t;
       myint count = 17;
       using position = float[3];

--- a/talk/basicconcepts/control.tex
+++ b/talk/basicconcepts/control.tex
@@ -77,7 +77,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{Control structures: switch}
   \begin{block}{Syntax}
-    \begin{cppcode*}{gobble=0}
+    \begin{cppcode*}{}
       switch(identifier) {
         case c1 : statements1; break;
         case c2 : statements2; break;

--- a/talk/basicconcepts/coresyntax.tex
+++ b/talk/basicconcepts/coresyntax.tex
@@ -169,7 +169,7 @@
             \item Custom conversion and promotion rules
         \end{itemize}
     \end{block}
-    \begin{cppcode*}{gobble=4}
+    \begin{cppcode*}{}
         #include <stdfloat> // may define these:
 
         std::float16_t  = 3.14f16;  // 16 (1+5+10) bit float

--- a/talk/basicconcepts/functions.tex
+++ b/talk/basicconcepts/functions.tex
@@ -3,7 +3,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{Functions}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       // with return type
       int square(int a) {
         return a * a;
@@ -16,7 +16,7 @@
       }
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=11}
+    \begin{cppcode*}{firstnumber=11}
       // no return
       void log(char* msg) {
         std::cout << msg;
@@ -43,7 +43,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{Function default arguments}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       // must be the trailing
       // argument
       int add(int a,
@@ -55,7 +55,7 @@
 
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=11}
+    \begin{cppcode*}{firstnumber=11}
       // multiple default
       // arguments are possible
       int add(int a = 2,
@@ -361,7 +361,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
         \end{itemize}
     \end{block}
     \begin{exampleblock}{}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
             int sum(int b);             // 1
             int sum(int b, int c);      // 2, ok, overload
             // float sum(int b, int c); // disallowed
@@ -399,7 +399,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
       \end{itemize}
     \end{goodpractice}
     \begin{exampleblock}{Example: Good}
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
         /// Count number of dilepton events in data.
         /// \param d Dataset to search.
         unsigned int countDileptons(Data &d) {
@@ -413,7 +413,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
   \begin{onlyenv}<2->
     \begin{alertblock}{Example: don't! Everything in one long function}
       \begin{multicols}{2}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           unsigned int runJob() {
             // Step 1: data
             Data data;
@@ -430,7 +430,7 @@ void fWrite(T &value);     fWrite(a); // non-const ref
             for (....) {
         \end{cppcode*}
         \columnbreak
-        \begin{cppcode*}{gobble=6,firstnumber=last}
+        \begin{cppcode*}{firstnumber=last}
               if (...) {
                 data.erase(...);
               }

--- a/talk/basicconcepts/references.tex
+++ b/talk/basicconcepts/references.tex
@@ -11,7 +11,7 @@
   \end{block}
 
   \begin{exampleblock}{Example:}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       int i = 2;
       int &iref = i; // access to i
       iref = 3;      // i is now 3

--- a/talk/basicconcepts/scopesnamespaces.tex
+++ b/talk/basicconcepts/scopesnamespaces.tex
@@ -122,7 +122,7 @@ int a = 1;
   \item They can be embedded to create hierarchies (separator is '::')
   \end{itemize}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       int a;
       namespace n {
         int a;   // no clash
@@ -138,7 +138,7 @@ int a = 1;
       }
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=14}
+    \begin{cppcode*}{firstnumber=14}
       namespace p { // reopen p
         void f() {
           p::a = 6;
@@ -207,7 +207,7 @@ int a = 1;
     \end{itemize}
   \end{block}
   \begin{alertblock}{Supersedes static}
-    \begin{cppcode*}{gobble=2,firstnumber=4}
+    \begin{cppcode*}{firstnumber=4}
       static int localVar; // equivalent C code
     \end{cppcode*}
   \end{alertblock}
@@ -226,7 +226,7 @@ int a = 1;
     \end{cppcode*}
   \end{alertblock}
   \begin{alertblock}{Never use in headers at global scope!}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       #include "PoorlyWritten.h" // using namespace std;
       struct array { ... };
       array a;  // Error: name clash with std::array

--- a/talk/concurrency/atomic.tex
+++ b/talk/concurrency/atomic.tex
@@ -96,7 +96,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblock}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       int a{0};
       std::thread t1([&]{ std::atomic_ref<int> r{a}; r++;});
       std::thread t2([&]{ std::atomic_ref{a}++; });
@@ -106,7 +106,7 @@
     \end{cppcode*}
   \end{exampleblock}
   \begin{alertblock}{Don't mix concurrent atomic and non-atomic access}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       std::thread t3([&]{ std::atomic_ref{a}++; });
       a += 2; // data race
       t3.join();

--- a/talk/concurrency/condition.tex
+++ b/talk/concurrency/condition.tex
@@ -81,7 +81,7 @@
   \end{overprint}
 
   \begin{alertblock}{Na\"ive waiting}
-    \begin{cppcode*}{gobble=2,highlightlines=3}
+    \begin{cppcode*}{highlightlines=3}
       auto processData = [&](){
         std::unique_lock<std::mutex> lock{mutex};
         cond.wait(lock, [&](){ return data.isReady(); });
@@ -101,7 +101,7 @@
   \end{block}
 
   \begin{exampleblock}{Correct waiting}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       auto processData = [&](){
         {
           std::unique_lock<std::mutex> lock{mutex};

--- a/talk/concurrency/mutexes.tex
+++ b/talk/concurrency/mutexes.tex
@@ -126,7 +126,7 @@
     \end{itemize}
   \end{goodpractice}
   \begin{exampleblock}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       void function(...) {
         // uncritical work ...
         {
@@ -210,7 +210,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblock}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Data data; std::shared_mutex mutex;
       auto reader = [&](){
         std::shared_lock lock{mutex};
@@ -236,7 +236,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblock}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       void worker(const int id, std::ostream & os);
       void func() {
         std::osyncstream synccout1{std::cout};

--- a/talk/concurrency/threadsasync.tex
+++ b/talk/concurrency/threadsasync.tex
@@ -11,7 +11,7 @@
   \end{block}
 
   \begin{exampleblock}{Example code}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       void foo() {...}
       void bar() {...}
       int main() {
@@ -59,7 +59,7 @@
   \end{goodpractice}
 
   \begin{exampleblock}{Example with jthread}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       void foo() {...}
       void bar() {...}
       int main() {

--- a/talk/expert/coroutines.tex
+++ b/talk/expert/coroutines.tex
@@ -5,14 +5,14 @@
   \begin{block}{The generator use case (one of several)}
     In python one can write
     {\scriptsize
-      \begin{pythoncode*}{gobble=2}
+      \begin{pythoncode*}{}
         for i in range(0, 10):
           print(i)
       \end{pythoncode*}
     }
     What about it in \cpp?
     {\scriptsize
-      \begin{cppcode*}{gobble=2, firstnumber=3}
+      \begin{cppcode*}{firstnumber=3}
         someType range(int first, int last) { ... }
         for (auto i : range(0, 10)) {
           std::cout << i << "\n";
@@ -35,7 +35,7 @@
   \frametitlecpp[20]{What \cpp20 allows}
   \begin{exampleblock}{Interesting part of the implementation (see \href{https://en.cppreference.com/w/cpp/coroutine/coroutine\_handle\#Example}{\color{blue!50!white}cppreference})}
     {\scriptsize
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
         template<std::integral T>
         Generator<T> range(T first, const T last) {
           while (first < last) {
@@ -92,7 +92,7 @@
   \frametitlecpp[20]{Minimal code}
   \begin{block}{Definition of an empty coroutine}
     {\scriptsize
-      \begin{cppcode*}{gobble=2, firstnumber=3}
+      \begin{cppcode*}{firstnumber=3}
         #include <coroutine>
         struct Task {
           struct promise_type {
@@ -184,7 +184,7 @@
   \end{block}
   \begin{exampleblock}{Code}
     {\scriptsize
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         Task myCoroutine() {
           std::cout << "Step 1 of coroutine\n";
           co_await std::suspend_always{};
@@ -214,7 +214,7 @@
   \end{block}
   \begin{exampleblock}{Code}
     {\scriptsize
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         struct Task {
           struct promise_type {
             Task get_return_object() {
@@ -235,7 +235,7 @@
   \frametitlecpp[20]{Resuming a coroutine}
   \scriptsize
   \begin{exampleblockGB}{User code}{https://godbolt.org/z/qx46Pa4v3}{Coroutine resumption}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Task myCoroutine() {
         std::cout << "Step 1 of coroutine\n";
         co_await std::suspend_always{};
@@ -254,7 +254,7 @@
     \end{cppcode*}
   \end{exampleblockGB}
   \begin{block}{}
-    \begin{minted}[gobble=4]{text}
+    \begin{minted}{text}
       Step 1 of coroutine
       In main, between Step 1 and 2
       Step 2 of coroutine
@@ -278,7 +278,7 @@
       \begin{itemize}
       \item which requires another piece of code in \cppinline{Task}, e.g.
         {\scriptsize
-          \begin{cppcode*}{gobble=8,linenos=false}
+          \begin{cppcode*}{linenos=false}
             ~Task() { if (h_) h_.destroy(); }
           \end{cppcode*}
         }
@@ -304,7 +304,7 @@
   \end{block}
   \begin{exampleblock}{Typical code}
     {\scriptsize
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         template<typename T> struct Task {
           struct promise_type {
             T value_;
@@ -325,7 +325,7 @@
   \frametitlecpp[20]{\texttt{co\_yield} - generator behavior}
   \begin{block}{Generator behavior - more boiler plate code}
     {\scriptsize
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         template<typename T>
         struct Task {
           struct iterator {
@@ -352,7 +352,7 @@
   \frametitlecpp[20]{\texttt{co\_yield} - final usage}
   \begin{exampleblockGB}{Finally, we can use the generator nicely}{https://godbolt.org/z/6bbrYrss5}{\texttt{co\_yield}}
     {\scriptsize
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         Task range(int first, int last) {
           while (first != last) {
             co_yield first++;
@@ -371,7 +371,7 @@
     \item we should pause in \cppinline{initial_suspend}
     \end{itemize}
      {\scriptsize
-      \begin{cppcode*}{gobble=4,firstnumber=10}
+      \begin{cppcode*}{firstnumber=10}
         struct Task {
           struct promise_type {
             ...
@@ -387,7 +387,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Laziness allows for infinite ranges}
   \begin{exampleblockGB}{Generators do not need to be finite}{https://godbolt.org/z/MP6qdGWYe}{Infinite generator}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Task range(int first) {
         while (true) {
           co_yield first++;
@@ -404,7 +404,7 @@
   \frametitlecpp[20]{Real life example}
   \begin{exampleblockGB}{A Fibonacci generator, from \cpprefLink{https://en.cppreference.com/w/cpp/language/coroutines}}{https://godbolt.org/z/3Pev1M8se}{Fibonacci generator}
     \scriptsize
-     \begin{cppcode*}{gobble=2}
+     \begin{cppcode*}{}
        Task<long long int> fibonacci(unsigned n) {
          if (n==0) co_return;
          co_yield 0;
@@ -497,7 +497,7 @@
   \frametitlecpp[20]{\texttt{awaiter} example}
   \begin{exampleblockGB}{Switch to new thread, from \cpprefLink{https://en.cppreference.com/w/cpp/language/coroutines}}{https://godbolt.org/z/K7svE4P7s}{Thread switching}
     \scriptsize
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       auto switch_to_new_thread(std::jthread& out) {
         struct awaiter {
           std::jthread* th;
@@ -531,7 +531,7 @@
       \raggedright
       \begin{block}{Output}
         \scriptsize
-        \begin{minted}[gobble=9]{text}
+        \begin{minted}{text}
           Started on thread: 140144191063872
           New thread ID: 140144191059712
           Resumed on thread: 140144191059712

--- a/talk/expert/cpp20concepts.tex
+++ b/talk/expert/cpp20concepts.tex
@@ -115,7 +115,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \end{block}
     \begin{exampleblock}{A new keyword: \texttt{concept}}
       \small
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
       template< typename T>
       concept MyFloatingPoint =
         std::is_floating_point_v<T> &&
@@ -138,7 +138,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \end{block}
     \begin{exampleblock}{}
       \small
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
       template<MyFloatingPoint T>
       bool equal( T e1, T e2 ) {
         return std::abs(e1-e2)<std::numeric_limits<T>::epsilon();
@@ -151,7 +151,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
       \end{itemize}
     \end{block}
     \begin{exampleblock}{Example code}
-      \begin{cppcode*}{firstnumber=4,gobble=2}
+      \begin{cppcode*}{firstnumber=4}
       MyFloatingPoint auto f = 3.14f;
       MyFloatingPoint auto d = 3.14;
       MyFloatingPoint auto i = 3; // compile error
@@ -175,7 +175,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \end{block}
     \begin{exampleblock}{}
       \small
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
       // no template <...> here!
       bool equal( MyFloatingPoint auto e1,
                   MyFloatingPoint auto e2 ) {
@@ -199,7 +199,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \end{block}
     \begin{exampleblock}{E.g.: the floating point concept}
       \small
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
       #include <concepts>
       bool equal( std::floating_point auto e1,
                   std::floating_point auto e2 ) {
@@ -223,7 +223,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \end{block}
     \begin{exampleblock}{Using concepts with \texttt{if constexpr}}
       \small
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
       template<typename T>
       bool equal( T e1, T e2 )
       {
@@ -250,7 +250,7 @@ using enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp 
     \end{block}
     \begin{exampleblock}{Practically}
       \small
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
       template<typename T>
       concept StreamableAndComparableNumber =
       requires( T v1, T v2, std::ostream os ) {

--- a/talk/expert/modules.tex
+++ b/talk/expert/modules.tex
@@ -28,7 +28,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Writing modules}
   \begin{exampleblock}{ratio.cpp}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
       import <string>;
       namespace utils { // ns. and module names orthogonal
@@ -39,7 +39,7 @@
     \end{cppcode*}
   \end{exampleblock}
   \begin{exampleblock}{main.cpp}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       import <iostream>;
       import math;
       int main() {
@@ -66,7 +66,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Writing modules}
   \begin{exampleblock}{What to export}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
 
       export void f();           // function
@@ -89,7 +89,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Writing modules}
   \begin{alertblock}{What not to export}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
 
       namespace {
@@ -110,14 +110,14 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Visibility and reachability}
   \begin{exampleblock}{ratio.cpp}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
       struct Ratio { float num, denom; };
       export Ratio golden() { ... } // golden is visible
     \end{cppcode*}
   \end{exampleblock}
   \begin{exampleblock}{main.cpp}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       import math;
       import <iostream>;
       int main() {
@@ -136,7 +136,7 @@
   \frametitlecpp[20]{Module structure}
   \begin{exampleblock}{}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       module;                  // global module fragment (opt.)
       #include <cassert>       //   only preprocessor
       // ...                   //   statements allowed
@@ -160,7 +160,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Module structure}
   \begin{alertblock}{Pitfall}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
       #include <header.h>
       import <string>;
@@ -174,7 +174,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblock}{Put includes into global module fragment}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       module;
       #include <vector>
       export module math;
@@ -190,7 +190,7 @@
     Like with header files, we can split interface and implementation:
   \end{block}
   \begin{exampleblock}{Interface}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
 
       export struct S { ... };
@@ -198,7 +198,7 @@
     \end{cppcode*}
   \end{exampleblock}
   \begin{exampleblock}{Implementation}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       module;
       #include <cassert>
       module math;
@@ -219,7 +219,7 @@
   \begin{columns}[t]
     \begin{column}{.45\textwidth}
       \begin{exampleblock}{Module one}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           export module one;
 
           export struct S { ... };
@@ -228,7 +228,7 @@
     \end{column}
     \begin{column}{.45\textwidth}
       \begin{exampleblock}{Module two}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           export module two;
           import <string>;
 
@@ -241,7 +241,7 @@
   \begin{columns}[t]
     \begin{column}{.45\textwidth}
       \begin{exampleblock}{Module three}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           export module three;
           import one;
           export import two;
@@ -252,7 +252,7 @@
     \end{column}
     \begin{column}{.45\textwidth}
       \begin{exampleblock}{Module four}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           export module four;
           import three;
           // b and f visible
@@ -273,7 +273,7 @@
   \begin{columns}[t]
     \begin{column}{.4\textwidth}
       \begin{exampleblock}{Primary module interface}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           export module math;
           export import :structs;
 
@@ -283,7 +283,7 @@
     \end{column}
     \begin{column}{.5\textwidth}
       \begin{exampleblock}{Module interface partition}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
 
           export module math:structs;
 
@@ -293,7 +293,7 @@
     \end{column}
   \end{columns}
   \begin{exampleblock}{Implementation}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       module math;
       import <string>;
 
@@ -309,7 +309,7 @@
     We can split a module's \emph{implementation} into multiple files:
   \end{block}
   \begin{exampleblock}{Interface}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       export module math;
       import :foo; // no export
       import :bar; // no export
@@ -324,7 +324,7 @@
   \begin{columns}[t]
     \begin{column}{.45\textwidth}
       \begin{exampleblock}{Implementation unit foo}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           module math:foo;
 
           S f() { ... }
@@ -333,7 +333,7 @@
     \end{column}
     \begin{column}{.45\textwidth}
       \begin{exampleblock}{Implementation unit bar}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           module math:bar;
 
           std::string b() { ... }
@@ -355,7 +355,7 @@
       \end{itemize}
       \item Use \cppinline|import std.compat;| for the entire C and C++ standard library
       \item No macros are exported. For these, you still need to include the corresponding headers.
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         import std;        // everything C++
         #include <cassert> // for assert()
         #include <climits> // for e.g. CHAR_BIT
@@ -427,26 +427,26 @@
   \begin{columns}
     \begin{column}{.35\textwidth}
       \begin{block}{h.hpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           #include <vector>
           ...
         \end{cppcode*}
       \end{block}
       \begin{block}{a.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           #include "h.hpp"
           ...
         \end{cppcode*}
       \end{block}
       \begin{block}{b.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           #include <vector>
           #include "h.hpp"
           ...
         \end{cppcode*}
       \end{block}
       \begin{block}{c.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           #include <vector>
           ...
         \end{cppcode*}
@@ -498,27 +498,27 @@
     \begin{column}{.35\textwidth}
       \small
       \begin{block}{h.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           export module foo;
           import <vector>;
           ...
         \end{cppcode*}
       \end{block}
       \begin{block}{a.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           import foo;
           ...
         \end{cppcode*}
       \end{block}
       \begin{block}{b.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           import <vector>;
           import foo;
           ...
         \end{cppcode*}
       \end{block}
       \begin{block}{c.cpp}
-        \begin{cppcode*}{gobble=6,linenos=false}
+        \begin{cppcode*}{linenos=false}
           #include <vector>
           ...
         \end{cppcode*}

--- a/talk/expert/perfectforwarding.tex
+++ b/talk/expert/perfectforwarding.tex
@@ -180,7 +180,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[20]{Forwarding references}
   \begin{alertblock}{Careful!}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template <typename T> struct S {
         S(T&& t) { ... }       // rvalue references
         void f(T&& t) { ... }  // NOT forwarding references
@@ -191,7 +191,7 @@
   \begin{overprint}
   \onslide<1>
   \begin{exampleblock}{Half-way correct version}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template <typename T> struct S {
 
         template <typename U>
@@ -204,7 +204,7 @@
   \end{exampleblock}
   \onslide<2>
   \begin{exampleblock}{Correct version}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template <typename T> struct S {
         template <typename U, std::enable_if_t<
           std::is_same_v<std::decay_t<U>, T>, int> = 0>

--- a/talk/expert/sfinae.tex
+++ b/talk/expert/sfinae.tex
@@ -159,7 +159,7 @@
     \end{itemize}
   \end{block}
   \begin{block}{Implementation in header type\_traits}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template <typename...>
       using void_t = void;
     \end{cppcode*}
@@ -284,7 +284,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[14]{Back to variadic class templates}
   \begin{block}{The tuple get function}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template <size_t I, typename... Ts>
       std::enable_if_t<I == 0,
         typename tuple_element<0, tuple<Ts...>>::type&>
@@ -304,7 +304,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[17]{with if constexpr and return type deduction}
   \begin{block}{The tuple get function}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template <size_t I, typename T, typename... Ts>
       auto& get(tuple<T, Ts...>& t) {
         if constexpr(I == 0)

--- a/talk/morelanguage/exceptions.tex
+++ b/talk/morelanguage/exceptions.tex
@@ -21,7 +21,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{fontsize=\small,gobble=2}
+    \begin{cppcode*}{fontsize=\small}
       try {
         process_data(f);
       } catch (const
@@ -30,7 +30,7 @@
       }
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{fontsize=\small,firstnumber=7,gobble=2}
+    \begin{cppcode*}{fontsize=\small,firstnumber=7}
       void process_data(file &f) {
         ...
         if (i >= buffer.size())
@@ -172,7 +172,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class C { ... };
       void f() {
         C c1;
@@ -185,7 +185,7 @@
       }
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=11}
+    \begin{cppcode*}{firstnumber=11}
       int main() {
         try {
           C c4;
@@ -233,7 +233,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{fontsize=\scriptsize,gobble=2}
+    \begin{cppcode*}{fontsize=\scriptsize}
       try {
         for (File const &f : files) {
           try {
@@ -248,7 +248,7 @@
       }
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{fontsize=\scriptsize,gobble=2}
+    \begin{cppcode*}{fontsize=\scriptsize}
       void process_file(File const & file) {
         ...
         if (handle = open_file(file))
@@ -278,7 +278,7 @@
   \begin{multicols}{2}
     \begin{minipage}{5cm}
       \begin{alertblock}{Avoid}
-        \begin{cppcode*}{fontsize=\scriptsize,gobble=6,linenos=false}
+        \begin{cppcode*}{fontsize=\scriptsize,linenos=false}
           for (string const &num: nums) {
             try {
               int i = convert(num); // can
@@ -294,7 +294,7 @@
     \columnbreak
     \begin{minipage}{5cm}
       \begin{exampleblock}{Prefer}
-        \begin{cppcode*}{fontsize=\scriptsize,gobble=6,linenos=false}
+        \begin{cppcode*}{fontsize=\scriptsize,linenos=false}
           for (string const &num: nums) {
             optional<int> i = convert(num);
             if (i) {
@@ -314,7 +314,7 @@
   \begin{block}{\texttt{noexcept}}
     \begin{itemize}
       \item a function with the \cppinline{noexcept} specifier states that it guarantees to not throw an exception
-      \begin{cppcode*}{gobble=2,linenos=false}
+      \begin{cppcode*}{linenos=false}
         int f() noexcept;
       \end{cppcode*}
       \begin{itemize}
@@ -323,7 +323,7 @@
         \item allows the compiler to optimize around that knowledge
       \end{itemize}
       \item a function with \cppinline{noexcept(expression)} is only \cppinline{noexcept} when \cppinline{expression} evaluates to \cppinline{true} at compile-time
-      \begin{cppcode*}{gobble=2,linenos=false}
+      \begin{cppcode*}{linenos=false}
         int safe_if_8B() noexcept(sizeof(long)==8);
       \end{cppcode*}
     \end{itemize}
@@ -346,13 +346,13 @@
     \end{itemize}
   \end{block}
   \begin{block}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       constexpr bool callCannotThrow = noexcept(f());
       if constexpr (callCannotThrow) { ... }
     \end{cppcode*}
   \end{block}
   \begin{block}{}
-    \begin{cppcode*}{gobble=2,firstnumber=3}
+    \begin{cppcode*}{firstnumber=3}
       template <typename Function>
       void g(Function f) noexcept(noexcept(f())) {
         ...

--- a/talk/morelanguage/lambda.tex
+++ b/talk/morelanguage/lambda.tex
@@ -35,7 +35,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblock}{Usage example}
-    \begin{cppcode*}{firstnumber=4,gobble=2}
+    \begin{cppcode*}{firstnumber=4}
       int data[]{1,2,3,4,5};
       auto f = [](int i) {
         std::cout << i << " squared is " << i*i << '\n';
@@ -59,7 +59,7 @@
     \begin{itemize}
     \item Only way to specify return type for lambdas
     \item Allows to simplify inner type definition
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         class Equation {
           using ResultType = double;
           ResultType evaluate();
@@ -90,7 +90,7 @@
   \end{block}
   \pause
   \begin{alertblock}{Error}
-    \begin{minted}[gobble=6]{text}
+    \begin{minted}{text}
         error: 'increment' is not captured
           [](int x) { return x+increment; });
                                      ^
@@ -132,7 +132,7 @@
   \end{exampleblock}
   \pause
   \begin{alertblock}{Error}
-    \begin{minted}[gobble=4]{text}
+    \begin{minted}{text}
       error: assignment of read-only variable 'sum'
                [sum](int x) { sum += x; });
     \end{minted}
@@ -178,7 +178,7 @@
     \begin{columns}
       \scriptsize
       \begin{column}{.25\textwidth}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           int sum = 0, off = 1;
           auto l =
           [&sum, off]
@@ -194,7 +194,7 @@
         \end{cppcode*}
       \end{column}
       \begin{column}{.45\textwidth}
-        \begin{cppcode*}{gobble=6, firstnumber=13}
+        \begin{cppcode*}{firstnumber=13}
           int sum = 0, off = 1;
           struct __lambda4 {
             int& sum; int off;
@@ -249,7 +249,7 @@
     Inside a (non-static) member function, we can capture \cppinline{this}.
   \end{block}
   \begin{block}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       [   this](...) { use(*this); };
       [      &](...) { use(*this); };
       [&, this](...) { use(*this); };
@@ -260,7 +260,7 @@
   \end{block}
   \pause
   \begin{block}{}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       [   *this](...) { use(*this); }; // C++17
       [&, *this](...) { use(*this); }; // C++17
       [=, *this](...) { use(*this); }; // C++17
@@ -275,11 +275,11 @@
   \begin{block}{Generic lambdas (aka.\ polymorphic lambdas)}
     \begin{itemize}
       \item The type of lambda parameters may be \cppinline{auto}.
-      \begin{cppcode*}{linenos=false,gobble=4}
+      \begin{cppcode*}{linenos=false}
         auto add = [](auto a, auto b) { return a + b; };
       \end{cppcode*}
       \item The generated \cppinline{operator()} becomes a template function:
-      \begin{cppcode*}{linenos=false,gobble=4}
+      \begin{cppcode*}{linenos=false}
         template <typename T, typename U>
         auto operator()(T a, U b) const { return a + b; }
       \end{cppcode*}
@@ -287,10 +287,10 @@
     \end{itemize}
   \end{block}
   \begin{block}{Explicit template parameters (\cpp20)}
-      \begin{cppcode*}{linenos=false,gobble=4}
-        auto add = []<typename T>(T a, T b)
-          { return a + b; };
-      \end{cppcode*}
+    \begin{cppcode*}{linenos=false}
+      auto add = []<typename T>(T a, T b)
+      { return a + b; };
+    \end{cppcode*}
     \begin{itemize}
       \item The types of \cppinline{a} and \cppinline{b} must be the same.
     \end{itemize}
@@ -331,7 +331,7 @@
   \end{block}
   \begin{exampleblockGB}{Example}{https://godbolt.org/z/GoE6xM8EG}{\texttt{lambda \cpp20}}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct S {
         decltype([](int i) { std::cout << i; }) f;
       } s;

--- a/talk/morelanguage/morestl.tex
+++ b/talk/morelanguage/morestl.tex
@@ -217,7 +217,7 @@
   \end{block}
   \begin{exampleblockGB}{Practically}{https://godbolt.org/z/bxzEsM3de}{\texttt{variant visitor}}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct Visitor {
         auto operator()(int i)   {return "i:"+std::to_string(i);}
         auto operator()(float f) {return "f:"+std::to_string(f);}
@@ -242,7 +242,7 @@
   \end{block}
   \begin{exampleblockGB}{Practically}{https://godbolt.org/z/WcdnT1hra}{\texttt{variant $\lambda$ visitor}}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       template<typename... Ts> // covered in expert part
       struct Overload : Ts ... { using Ts::operator()...; };
       template<typename... Ts>
@@ -412,7 +412,7 @@
   \end{block}
   \begin{exampleblock}{}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class C { ... }; // complex, cannot change
       template <>
       struct std::tuple_size<C> {
@@ -459,7 +459,7 @@
   \frametitlecpp[11]{Practical usage / timing some \cpp code}
   \begin{exampleblockGB}{How to measure the time spent in some code}{https://godbolt.org/z/PzKWer5eb}{\texttt{timing}}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       #include <chrono>
 
       std::chrono::high_resolution_clock clock;

--- a/talk/morelanguage/move.tex
+++ b/talk/morelanguage/move.tex
@@ -47,7 +47,7 @@
   \begin{exampleblock}{Another potentially inefficient code}
     \begin{overprint}
       \onslide<1-2>
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         T consumeVector(std::vector<int> input) {
           // ... change elements, compute result
           return result;
@@ -57,7 +57,7 @@
         consumeVector(values); // being copied now
       \end{cppcode*}
       \onslide<3-4>
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         T consumeVector(std::vector<int> const & input) {
           std::vector tmp{input};
           // ... change elements, compute result
@@ -67,7 +67,7 @@
         consumeVector(values); // maybe copied internally?
       \end{cppcode*}
       \onslide<5->
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         T consumeVector(std::vector<int> & input) {
           // ... change elements, compute result
           return result;
@@ -223,7 +223,7 @@
   \frametitlecpp[11]{Move semantics: recommended implementation}
   \begin{exampleblock}{Practically}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class Movable {
         Movable();
         Movable(const Movable &other);
@@ -248,7 +248,7 @@
   \frametitlecpp[11]{Move semantics: alternative implementation}
   \begin{exampleblock}{Practically}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class Movable {
         Movable();
         Movable(const Movable &other);

--- a/talk/morelanguage/raii.tex
+++ b/talk/morelanguage/raii.tex
@@ -84,7 +84,7 @@
   \frametitlecpp[98]{RAII in practice}
   \begin{exampleblock}{An RAII File class}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class File {
       public:
         // constructor: acquire resource
@@ -337,7 +337,7 @@ of 'std::unique_ptr<Foo>'
   \frametitlecpp[11]{Quiz: \texttt{std::shared\_ptr} in use}
   \begin{exampleblockGB}{What is the output of this code?}{https://godbolt.org/z/vM35Y6qEW}{\texttt{shared\_ptr} quiz}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       auto shared = std::make_shared<int>(100);
       auto print = [shared](){
         std::cout << "Use: " << shared.use_count() << " "
@@ -355,7 +355,7 @@ of 'std::unique_ptr<Foo>'
   \pause
   \begin{block}{}
     \small
-    \begin{minted}[autogobble=true]{bash}
+    \begin{minted}{bash}
       Use: 2 value: 100
       Use: 3 value: 101
       Use: 2 value: 101
@@ -385,7 +385,7 @@ print();
   \end{exampleblock}
   \begin{block}{}
     \small
-    \begin{minted}[autogobble=true]{bash}
+    \begin{minted}{bash}
       Use: 1 value: 100
       Use: 2 value: 101
       Use: 1 value: 101
@@ -399,7 +399,7 @@ print();
   \frametitlecpp[11]{Quiz: \texttt{shared\_ptr} and \texttt{weak\_ptr} in use}
   \begin{exampleblockGB}{What is the output of this code?}{https://godbolt.org}{\texttt{shared/weak\_ptr}}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       auto shared = std::make_shared<int>(100);
       std::weak_ptr<int> weak{ shared };
       print(); // with print as before
@@ -415,7 +415,7 @@ print();
   \pause
   \begin{block}{}
     \small
-    \begin{minted}[autogobble=true]{bash}
+    \begin{minted}{bash}
       Use: 1 value: 100
       Use: 2 value: 101
       Use: 1 value: 101
@@ -457,7 +457,7 @@ print();
     \item compile and run the program. It doesn't generate any output.
     \item Run with valgrind if possible to check for leaks
       { \scriptsize
-      \begin{minted}[gobble=6]{shell-session}
+      \begin{minted}{shell-session}
         $ valgrind --leak-check=full --track-origins=yes ./smartPointers
       \end{minted}
       }

--- a/talk/morelanguage/random.tex
+++ b/talk/morelanguage/random.tex
@@ -85,7 +85,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblock}{Distributions sharing a non-deterministic engine}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       std::random_device rd;
       std::default_random_engine engine{rd()};
       std::uniform_int_distribution<int> dist(2,7);//min,max

--- a/talk/morelanguage/ranges.tex
+++ b/talk/morelanguage/ranges.tex
@@ -32,7 +32,7 @@
   \end{block}
   \begin{exampleblockGB}{Example}{https://godbolt.org/z/d1vTv4TMa}{Views}
     { \small
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         auto const numbers = std::views::iota(0, 6);
         auto even = [](int i) { return 0 == i % 2; };
         auto square = [](int i) { return i * i; };
@@ -72,7 +72,7 @@
     \end{itemize}
   \end{block}
   \begin{exampleblockGB}{Example}{https://godbolt.org/z/bWe6W69oE}{Lazy view}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       // print first 20 prime numbers above 1000000
       for (int i: std::views::iota(1000000)
                   | std::views::filter(odd)

--- a/talk/morelanguage/stl.tex
+++ b/talk/morelanguage/stl.tex
@@ -26,7 +26,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[14]{STL in practice}
   \begin{exampleblockGB}{STL example}{https://godbolt.org/z/n8ahEr5f6}{STL}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       #include <vector>
       #include <algorithm>
       #include <functional>     // `import std;` in C++23
@@ -127,7 +127,7 @@
     \begin{block}{}
         Conceptually a container of \cppinline{std::pair<Key const, Value>}
     \end{block}
-    \begin{cppcode*}{gobble=4}
+    \begin{cppcode*}{}
         #include <unordered_map>
         std::unordered_map<std::string, int> m;
         m["hello"] = 1;  // inserts new key, def. constr. value
@@ -154,7 +154,7 @@
             \item Can be customized for your types via template specialization
         \end{itemize}
     \end{block}
-    \begin{cppcode*}{gobble=4}
+    \begin{cppcode*}{}
         #include <functional>
         std::hash<std::string> h;
         std::cout << h("hello"); // 2762169579135187400

--- a/talk/morelanguage/templates.tex
+++ b/talk/morelanguage/templates.tex
@@ -43,7 +43,7 @@
   \begin{lrbox}{\codepiece}
     \begin{minipage}{.35\linewidth}
       \small
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         template<typename T>
         T func(T a) {
           return a;
@@ -55,7 +55,7 @@
   \begin{lrbox}{\codepiecea}
     \begin{minipage}{.4\linewidth}
       \small
-      \begin{cppcode*}{gobble=4,linenos=false}
+      \begin{cppcode*}{linenos=false}
         int func(int a) {
           return a;
         }
@@ -66,7 +66,7 @@
   \begin{lrbox}{\codepieceb}
     \begin{minipage}{.4\linewidth}
       \small
-      \begin{cppcode*}{gobble=4,linenos=false}
+      \begin{cppcode*}{linenos=false}
         double func(double a) {
           return a;
         }
@@ -159,7 +159,7 @@
     \frametitlecpp[98]{Nested templates}
     \begin{exampleblockGB}{Nested templates}{https://godbolt.org/z/a9nPnK9jx}{Nested templates}
         \small
-        \begin{cppcode*}{gobble=8}
+        \begin{cppcode*}{}
             template<typename KeyType=int, typename ValueType=KeyType>
             struct Map {
               template<typename OtherValueType>
@@ -282,7 +282,7 @@
     \onslide<1>
     \begin{alertblock}{}
       \footnotesize
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
         template <typename C>
         void f(typename C::value_type v) { ... }
         f(std::vector<int>{...}); // cannot deduce C
@@ -300,7 +300,7 @@
     \onslide<2>
     \begin{alertblock}{}
       \footnotesize
-      \begin{cppcode*}{gobble=2}
+      \begin{cppcode*}{}
         template <typename C, typename F>
         void reduce(const C& cont, const F& f = std::plus{});
         reduce(std::vector<int>{...}); // error: cannot deduce F
@@ -451,14 +451,14 @@
   \end{cppcode}
   \begin{overprint}[\columnwidth]
     \onslide<1>
-    \begin{cppcode*}{gobble=2,firstnumber=6}
+    \begin{cppcode*}{firstnumber=6}
 
 
 
       Pair p{42, "hello"}; // Pair<int, const char*>
     \end{cppcode*}
     \onslide<2>
-    \begin{cppcode*}{gobble=2,firstnumber=6}
+    \begin{cppcode*}{firstnumber=6}
       template<typename A>
       Pair(A, const char*) -> Pair<A, std::string>;
 
@@ -470,7 +470,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[17]{Class Template Argument Deduction (CTAD)}
   \begin{block}{Standard library examples}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       std::pair p{1.2, true}; // std::pair<double, bool>
       std::tuple t{1.2, true, 32};
                         // std::tuple<double, bool, int>

--- a/talk/objectorientation/adl.tex
+++ b/talk/objectorientation/adl.tex
@@ -60,7 +60,7 @@
       \begin{column}{.35\textwidth}
         Don't write :
         \vspace{-1mm}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           namespace MyNS {
             struct A {
               T func(...);
@@ -71,7 +71,7 @@
       \begin{column}{.35\textwidth}
         Prefer :
         \vspace{-1mm}
-        \begin{cppcode*}{gobble=6,firstnumber=6}
+        \begin{cppcode*}{firstnumber=6}
           namespace MyNS {
             struct A { ... };
             T func(const A&, ..);
@@ -99,14 +99,14 @@
     \begin{columns}[t]
       \begin{column}{.35\textwidth}
         Don't write :
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           N::A a,b;
           std::swap(a, b);
         \end{cppcode*}
       \end{column}
       \begin{column}{.35\textwidth}
         Prefer :
-        \begin{cppcode*}{gobble=6,firstnumber=3}
+        \begin{cppcode*}{firstnumber=3}
           N::A a,b;
           using std::swap;
           swap(a, b);
@@ -121,7 +121,7 @@
     \end{itemize}
     \begin{columns}
       \begin{column}{.7\textwidth}
-        \begin{cppcode*}{gobble = 6,firstnumber=6}
+        \begin{cppcode*}{firstnumber=6}
           namespace N {
             class A { ... };
             // optimized swap for A
@@ -146,7 +146,7 @@
   \end{block}
   \begin{exampleblock}{\texttt{operator<<} as hidden friend}
     \small
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class Complex {
         float m_real, m_imag;
       public:
@@ -175,7 +175,7 @@
     \footnotesize
     \begin{overprint}
     \onslide<1>
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       std::ostream & operator<< // out-of-class definition
         (std::ostream & os, Complex const & c) { ... }
       struct Fraction {
@@ -188,7 +188,7 @@
     \end{cppcode*}
 
     \onslide<2>
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       std::ostream & operator<< // out-of-class definition
         (std::ostream & os, Complex const & c) { ... }
       struct Fraction {

--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -48,7 +48,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Polygon p;
 
       int f(Drawable & d) {...}
@@ -99,7 +99,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Polygon p;
 
       int f(Drawable & d) {...}
@@ -132,7 +132,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Polygon p;
       p.draw(); // ?
 
@@ -168,7 +168,7 @@
   \begin{overprint}
   \onslide<2>
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       Polygon p;
       p.draw(); // Polygon.draw
 
@@ -192,7 +192,7 @@
 
   \onslide<3>
     \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2,highlightlines=5}
+    \begin{cppcode*}{highlightlines=5}
       Polygon p;
       p.draw(); // Polygon.draw
 
@@ -317,7 +317,7 @@
   \end{block}
   \pause
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       // Error : abstract class
       Shape s;
 
@@ -415,7 +415,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct Drawable {
         virtual ~Drawable()
                       = default;
@@ -440,7 +440,7 @@
     \item unless you inherit them using \cppinline{using}
     \end{itemize}
   \end{block}
-  \begin{cppcode*}{gobble=0}
+  \begin{cppcode*}{}
     struct BaseClass {
       virtual int foo(std::string);
       virtual int foo(int);
@@ -488,7 +488,7 @@
     \end{tikzpicture}
     \columnbreak
     \vspace{2cm}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class TextBox :
         public Rectangle, Text {
         // inherits from both

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -11,7 +11,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class C {
       public:
         C();
@@ -23,7 +23,7 @@
       };
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=10}
+    \begin{cppcode*}{firstnumber=10}
       // note: special notation for
       // initialization of members
       C::C() : a(0) {}
@@ -264,7 +264,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[11]{Calling constructors}
   \begin{block}{After object declaration, arguments within \{\}}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct A {
         int a;
         float b;
@@ -285,7 +285,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{Calling constructors the old way}
   \begin{block}{Arguments are given within (), aka \cpp98 nightmare}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct A {
         int a;
         float b;

--- a/talk/objectorientation/inheritance.tex
+++ b/talk/objectorientation/inheritance.tex
@@ -3,7 +3,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{First inheritance}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct MyFirstClass {
         int a;
         void squareA() { a *= a; }
@@ -61,7 +61,7 @@
     \end{itemize}
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class MyFirstClass {
       public:
         void setA(int x);
@@ -72,7 +72,7 @@
       };
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=9}
+    \begin{cppcode*}{firstnumber=9}
       MyFirstClass obj;
       obj.a = 5;   // error !
       obj.setA(5); // ok
@@ -92,7 +92,7 @@
     Gives access to classes inheriting from base class
   \end{block}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class MyFirstClass {
       public:
         void setA(int a);
@@ -103,7 +103,7 @@
       };
     \end{cppcode*}
     \columnbreak
-    \begin{cppcode*}{gobble=2,firstnumber=13}
+    \begin{cppcode*}{firstnumber=13}
       class MySecondClass :
         public MyFirstClass {
       public:
@@ -164,7 +164,7 @@
       \draw[very thick,-Triangle] (MyThirdClass)--(MySecondClass) node[midway,right] {public};
     \end{tikzpicture}
     \columnbreak
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       void funcSecond() {
         int a = priv;   // Error
         int b = prot;   // OK
@@ -206,7 +206,7 @@
       \draw[very thick,-Triangle] (MyThirdClass)--(MySecondClass) node[midway,right] {public};
     \end{tikzpicture}
     \columnbreak
-    \begin{cppcode*}{gobble=2,highlightlines=14}
+    \begin{cppcode*}{highlightlines=14}
       void funcSecond() {
         int a = priv;   // Error
         int b = prot;   // OK
@@ -248,7 +248,7 @@
       \draw[very thick,-Triangle] (MyThirdClass)--(MySecondClass) node[midway,right] {public};
     \end{tikzpicture}
     \columnbreak
-    \begin{cppcode*}{gobble=2,highlightlines=8-9}
+    \begin{cppcode*}{highlightlines=8-9}
       void funcSecond() {
         int a = priv;   // Error
         int b = prot;   // OK

--- a/talk/objectorientation/objectsclasses.tex
+++ b/talk/objectorientation/objectsclasses.tex
@@ -32,7 +32,7 @@
 \begin{frame}[fragile]
   \frametitlecpp[98]{My first class}
   \begin{multicols}{2}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct MyFirstClass {
         int a;
         void squareA() {
@@ -68,7 +68,7 @@
   \begin{columns}[t]
     \begin{column}{.45\textwidth}
     \begin{block}{Header: MyClass.hpp}
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         #pragma once
         struct MyClass {
           int a;
@@ -77,7 +77,7 @@
       \end{cppcode*}
     \end{block}
     \begin{block}{Implementation: MyClass.cpp}
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         #include "MyClass.hpp"
         void MyClass::squareA() {
           a *= a;
@@ -87,7 +87,7 @@
     \end{column}
     \begin{column}{.45\textwidth}
     \begin{block}{User 1: main.cpp}
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         #include "MyClass.hpp"
         int main() {
           MyClass mc;
@@ -96,7 +96,7 @@
       \end{cppcode*}
     \end{block}
     \begin{block}{User 2: fun.cpp}
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         #include "MyClass.hpp"
         void f(MyClass& mc) {
           mc.squareA();

--- a/talk/objectorientation/operators.tex
+++ b/talk/objectorientation/operators.tex
@@ -107,7 +107,7 @@
   \end{block}
   \begin{exampleblock}{\texttt{operator+} as a friend}
     \footnotesize
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       class Complex {
         float m_r, m_i;
         friend Complex operator+(Complex const & a, Complex const & b);

--- a/talk/objectorientation/typecasting.tex
+++ b/talk/objectorientation/typecasting.tex
@@ -24,7 +24,7 @@
   \frametitlecpp[98]{Type casting example}
   \small
   \begin{exampleblockGB}{Practically}{https://godbolt.org/z/16faqc64s}{\texttt{casting}}
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       struct A{ virtual ~A()=default; } a;
       struct B : A {} b;
 
@@ -67,7 +67,7 @@
   \end{block}
   \begin{alertblock}{Casts to avoid}
     \scriptsize
-    \begin{cppcode*}{gobble=2}
+    \begin{cppcode*}{}
       void func(A const & a) {
         A& ra = a;                 // Error: not const
         A& ra = const_cast<A&>(a); // Compiles. Bad design!

--- a/talk/python/ctypes.tex
+++ b/talk/python/ctypes.tex
@@ -28,7 +28,7 @@
     \end{cppcode*}
   \end{block}
   \begin{exampleblock}{calling the mandel library}
-    \begin{minted}[gobble=4]{python}
+    \begin{minted}{python}
       from ctypes import *
       libmandel = CDLL('libmandelc.so')
       v = libmandel.mandel(c_float(0.3), c_float(1.2))

--- a/talk/python/marryingcandcpp.tex
+++ b/talk/python/marryingcandcpp.tex
@@ -25,7 +25,7 @@
     \end{cppcode*}
   \end{exampleblock}
   \begin{block}{Binary symbols : file.o}
-    \begin{minted}[gobble=4]{shell}
+    \begin{minted}{shell}
       # nm file.o
       000000000000001a T square
       0000000000000000 T sum
@@ -44,7 +44,7 @@
     \end{cppcode*}
   \end{exampleblock}
   \begin{block}{Binary symbols : file.o}
-    \begin{minted}[gobble=4]{shell}
+    \begin{minted}{shell}
       # nm file.o
       0000000000000000 T _Z3sumff
       000000000000002a T _Z6squaref
@@ -57,7 +57,7 @@
   \frametitle{Forcing C mangling in \cpp}
   \begin{block}{extern ``C''}
     These functions will use C mangling :
-    \begin{cppcode*}{gobble=1}
+    \begin{cppcode*}{}
       extern "C" {
         float sum(float a, float b);
         int square(int a);

--- a/talk/python/modulewriting.tex
+++ b/talk/python/modulewriting.tex
@@ -61,7 +61,7 @@
     \end{itemize}
   \end{block}
   \begin{block}{mandel.py - see exercises/python exercise}
-    \begin{minted}[gobble=4]{python}
+    \begin{minted}{python}
       from mandel import mandel
       v = mandel(0.7, 1.2)
     \end{minted}

--- a/talk/setup.tex
+++ b/talk/setup.tex
@@ -50,11 +50,11 @@
 \usepackage[utf8]{inputenc}
 \usepackage{newunicodechar}
 \usepackage{minted}
-\newminted{tex}{linenos}
-\newminted{cpp}{gobble=4,linenos}
-\newminted{shell-session}{gobble=4}
-\newminted[makefile]{shell-session}{gobble=4}
-\newminted{python}{linenos=true,gobble=4}
+\newminted{tex}{linenos,gobble=4}
+\newminted{cpp}{autogobble,linenos}
+\newminted{shell-session}{autogobble}
+\newminted[makefile]{shell-session}{autogobble}
+\newminted{python}{linenos=true,autogobble}
 \newmintinline[cppinline]{cpp}{}
 
 \usepackage{fancyvrb}

--- a/talk/tools/doxygen.tex
+++ b/talk/tools/doxygen.tex
@@ -24,7 +24,7 @@
   \begin{block}{Comment blocks}
     \begin{columns}
       \begin{column}{.35\textwidth}
-        \begin{cppcode*}{gobble=6}
+        \begin{cppcode*}{}
           /**
            * text/directives ...
            */
@@ -37,7 +37,7 @@
         \end{cppcode*}
       \end{column}
       \begin{column}{.35\textwidth}
-        \begin{cppcode*}{gobble=6,firstnumber=10}
+        \begin{cppcode*}{firstnumber=10}
           ///
           /// text/directives ...
           ///

--- a/talk/tools/sanitizers.tex
+++ b/talk/tools/sanitizers.tex
@@ -39,12 +39,12 @@
     \begin{overprint}
       \onslide<1>
       \vfill
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         int i = *address;
       \end{cppcode*}
       \onslide<2->
       \vfill
-      \begin{cppcode*}{gobble=4}
+      \begin{cppcode*}{}
         if (IsPoisoned(address)) {
           ReportError(address, kAccessSize, kIsWrite);
         }
@@ -67,7 +67,7 @@
     \begin{multicols}{2}
       \begin{overprint}
         \onslide<1>
-        \begin{cppcode*}{gobble=4}
+        \begin{cppcode*}{}
           void foo() {
             char a[8];
             char b[8];

--- a/talk/tools/vcs.tex
+++ b/talk/tools/vcs.tex
@@ -28,7 +28,7 @@
 
 \begin{frame}[fragile]
   \frametitle{Git crash course}
-  \begin{minted}[gobble=4]{shell-session}
+  \begin{minted}{shell-session}
     $ git init myProject
     Initialized empty Git repository in myProject/.git/
 


### PR DESCRIPTION
And dropped (most of) the manual gobble= in the rest of the slides this has also fixed a couple of bad indentations here and there
