### PR TITLE
Small refinements for the OO chapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 package-lock.json
 package.json
 node_modules/**
+
+# Temporary latex files:
+talk/C++Course.*
+talk/_minted

--- a/talk/objectorientation/advancedoo.tex
+++ b/talk/objectorientation/advancedoo.tex
@@ -244,8 +244,7 @@
   \frametitlecpp[11]{{\texttt override} keyword}
   \begin{block}{Principle}
     \begin{itemize}
-    \item when overriding a virtual method
-    \item the \cppinline|override| keyword should be used
+    \item when overriding a virtual method, the \cppinline|override| keyword should be used
     \item the \cppinline|virtual| keyword is then optional
     \end{itemize}
   \end{block}

--- a/talk/objectorientation/allocations.tex
+++ b/talk/objectorientation/allocations.tex
@@ -37,7 +37,7 @@
     \item each thread in a process has its own stack
       \begin{itemize}
       \item allocations on the stack are thus ``thread private''
-      \item and do not introduce any thread safety issues
+      \item and do not introduce any thread-safety issues
       \end{itemize}
     \end{itemize}
   \end{block}
@@ -77,7 +77,7 @@
     \item there is a single, shared heap per process
       \begin{itemize}
       \item allows to share data between threads
-      \item introduces race conditions and thread safety issues!
+      \item introduces race conditions and thread-safety issues!
       \end{itemize}
     \end{itemize}
   \end{block}

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -106,6 +106,27 @@
 
 \begin{frame}[fragile]
   \frametitlecpp[98]{Class Constructors and Destructors}
+  \begin{overprint}
+    \onslide<1>
+  \begin{cppcode}
+    class Vector {
+    public:
+      Vector(int n);
+      Vector(const Vector &other);
+      ~Vector();
+    private:
+      int len; int* data;
+    };
+    Vector::Vector(int n) : len(n) {
+      data = new int[n];
+    }
+
+
+
+
+    Vector::~Vector() { delete[] data; }
+  \end{cppcode}
+    \onslide<2>
   \begin{cppcode}
     class Vector {
     public:
@@ -124,6 +145,8 @@
     }
     Vector::~Vector() { delete[] data; }
   \end{cppcode}
+
+  \end{overprint}
 \end{frame}
 
 \begin{frame}[fragile]
@@ -266,8 +289,8 @@
   \begin{block}{After object declaration, arguments within \{\}}
     \begin{cppcode*}{}
       struct A {
-        int a;
-        float b;
+        int i;
+        float f;
         A();
         A(int);
         A(int, int);
@@ -287,8 +310,8 @@
   \begin{block}{Arguments are given within (), aka \cpp98 nightmare}
     \begin{cppcode*}{}
       struct A {
-        int a;
-        float b;
+        int i;
+        float f;
         A();
         A(int);
         A(int, int);

--- a/talk/objectorientation/constructors.tex
+++ b/talk/objectorientation/constructors.tex
@@ -226,7 +226,7 @@
     \begin{cppcode}
       struct Delegate {
         int m_i;
-        Delegate(int i) : m_i(i) {
+        explicit Delegate(int i) : m_i(i) {
           ... complex initialization ...
         }
         Delegate() : Delegate(42) {}
@@ -247,7 +247,7 @@
   \begin{exampleblock}{Practically}
     \begin{cppcode}
       struct Base {
-        Base(int a);           // ctor 1
+        explicit Base(int a);  // ctor 1
       };
       struct Derived : Base {
         using Base::Base;
@@ -270,9 +270,9 @@
   \begin{exampleblock}{Practically}
     \begin{cppcode}
       struct Base {
-        int a{5}; // also possible: int a = 5;
-        Base() = default;
-        Base(int _a) : a(_a) {}
+        int a{5}; // or: int a = 5;
+                 Base() = default;
+        explicit Base(int _a) : a(_a) {}
       };
       struct Derived : Base {
         int b{6};

--- a/talk/objectorientation/operators.tex
+++ b/talk/objectorientation/operators.tex
@@ -7,8 +7,8 @@
       float m_real, m_imaginary;
       Complex(float real, float imaginary);
       Complex operator+(const Complex& other) {
-        return Complex(m_real + other.m_real,
-                       m_imaginary + other.m_imaginary);
+        return Complex{m_real + other.m_real,
+                       m_imaginary + other.m_imaginary};
       }
     };
 
@@ -57,7 +57,7 @@
       struct Complex {
         float m_real, m_imaginary;
         Complex operator+(float other) {
-          return Complex(m_real + other, m_imaginary);
+          return Complex{m_real + other, m_imaginary};
         }
       };
       Complex c1{2.f, 3.f};
@@ -67,7 +67,7 @@
     \pause
     \begin{cppcode*}{firstnumber=10}
       Complex operator+(float a, const Complex& obj) {
-        return Complex(a + obj.m_real, obj.m_imaginary);
+        return Complex{a + obj.m_real, obj.m_imaginary};
       }
     \end{cppcode*}
   \end{block}
@@ -102,7 +102,7 @@
       \item They gain access to all private/protected members
       \item Useful for operators such as \cppinline{a + b}
       \item Don't abuse friends to go around a wrongly designed interface
-      \item Avoid unexpected modifications of class state in a friend
+      \item Avoid unexpected modifications of class state in a friend!
     \end{itemize}
   \end{block}
   \begin{exampleblock}{\texttt{operator+} as a friend}


### PR DESCRIPTION
- Convert a few constructor calls from `(1, 2)` to `{1, 2}`.
- Add some `explicit` keywords to follow our own recommendations.
- Small typographic refinements