### PR TITLE
Fix operators.cpp -> printer.process macro to accept multiple values

### DIFF
--- a/exercises/operators/operators.cpp
+++ b/exercises/operators/operators.cpp
@@ -62,7 +62,7 @@ private:
 // (the what argument) to a pair containing a string representation
 // of it and the code itself. That way, print is given a string and a
 // value where the string is the code that lead to the value
-#define CHECK(printer,what) printer.process(#what, what)
+#define CHECK(printer, ...) printer.process(#__VA_ARGS__, (__VA_ARGS__))
 
 int main() {
 


### PR DESCRIPTION
This Pull request fixes the following issue:
When implementing the operators, some would want to write `CHECK(p1,three == Fraction{3,1});`, but the compiler complains with the following error:
```
operators.cpp:109:34: error: macro ‘CHECK’ passed 3 arguments, but takes just 2
  109 |   CHECK(p1,three == Fraction{3,1}); //why double parenthesis
      |                                  ^
operators.cpp:93:9: note: macro ‘CHECK’ defined here
   93 | #define CHECK(printer, what) printer(#what, what)
      |         ^~~~~
operators.cpp: In function ‘int main()’:
operators.cpp:109:3: error: ‘CHECK’ was not declared in this scope
  109 |   CHECK(p1,three == Fraction{3,1}); //why double parenthesis
      |   ^~~~~
make: *** [Makefile:8: operators] Error 1
```
So it is mandatory to include an additional `()`, like so: `CHECK(p1,(three == Fraction{3,1}));`

This Pull request makes it possible to write it in a shorter form: `CHECK(p1,three == Fraction{3,1});`