### PR TITLE
Fix an indentation error in build-exercises.yml

### DIFF
--- a/.github/workflows/build-exercises.yml
+++ b/.github/workflows/build-exercises.yml
@@ -40,7 +40,7 @@ jobs:
           - NAME: "modern_oo"
           - NAME: "move"
           - NAME: "classes"
-           SKIP_DEFAULT: true
+            SKIP_DEFAULT: true
           - NAME: "operators"
           - NAME: "optional"
           - NAME: "polymorphism"


### PR DESCRIPTION
The CI wasn't running because of an indentation error in the matrix strategy.