### PR TITLE
Use prefix operator in the example of non thread safe code

### DIFF
--- a/talk/concurrency/mutexes.tex
+++ b/talk/concurrency/mutexes.tex
@@ -5,7 +5,7 @@
   \begin{exampleblockGB}{Example code}{https://godbolt.org/z/oGz61Pn19}{Race}
     \begin{cppcode*}{}
       int a = 0;
-      void inc() { a++; };
+      void inc() { ++a; };
       void inc100() {
         for (int i=0; i < 100; i++) inc();
       };


### PR DESCRIPTION
So that to not interfere with the core discussion on that slide, as it's true that the postfix operator creates a temporary which complexifies the picture